### PR TITLE
Update power_board_node.py

### DIFF
--- a/panther_power_control/src/power_board_node.py
+++ b/panther_power_control/src/power_board_node.py
@@ -196,6 +196,7 @@ class PowerBoardNode:
             self._reset_e_stop()
 
             if self._validate_gpio_pin(self._pins.E_STOP_RESET, True):
+                self._watchdog.turn_off()
                 return TriggerResponse(
                     False,
                     'E-STOP reset failed, check for pressed E-STOP buttons or other triggers',


### PR DESCRIPTION
After a failed attempt to reset the e-stop, the RPi continued to try to reset it (watchdog enabled). The changes are intended to cause the watchdog to turn off while sending information about the e-stop reset failure.