### PR TITLE
Ros1 update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ This will launch Gazebo and Rviz.
 
 ## Robot configuration
 
-Parameters stored in [**panther_default.yaml**](./panther_bringup/config/panther_default.yaml) are generic and are overwritten with your specific panther configuration on start.
+Parameters stored in [**panther_default.yaml**](./panther_bringup/config/panther_default.yaml) are generic and are overwritten with your specific Panther configuration on start.
+
+### Changing wheels type
 
 In order to change wheels used with your robot, add `wheel_type:=WH0X` to launch command as follows:
 ``` bash
@@ -91,8 +93,29 @@ Possible wheels names:
 - `WH01`: default offroad wheels.
 - `WH02`: mecanum.
 - `WH04`: small pneumatic wheels.
+- `custom`: custom wheels type.
 
 If you want to use custom wheels, use argument `wheel_config_file` where you provide a path to `wheel.yaml` file. The file has to be written in the same manner as default panther wheel configurations found in [**WH01.yaml**](./panther_description/config/WH01.yaml).
+
+### Providing custom robot description
+
+By default Panther will launch the default robot description - raw robot without any sensors. There are two ways of providing custom robot description, which are described below.
+
+**a) Disabling the default robot state publisher**
+
+If you want to use a custom robot description from a different location within your project, you can disable the default `robot_state_publisher` and run it separately. To do this, use the `publish_robot_state` launch argument with a value of **false**:
+
+```bash
+roslaunch panther_bringup bringup.launch publish_robot_state:=false
+```
+
+**b) Providing custom robot description**
+
+Alternatively, you can provide a custom robot description directly using the `robot_description` launch argument. For example:
+
+```bash
+roslaunch panther_bringup bringup.launch robot_description:="xacro $(rospack find my_awesome_package)/urdf/panther.urdf.xacro"
+```
 
 ## Shutting down User Computers
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Parameters stored in [**panther_default.yaml**](./panther_bringup/config/panther
 
 ### Changing wheels type
 
-In order to change wheels used with your robot, add `wheel_type:=WH0X` to launch command as follows:
+Changing the wheels requires changing the `wheel_type` parameter. To do this, you can use the following command by modifying the value of the wheel_type:=WH0X parameter:
 ``` bash
 roslaunch panther_bringup bringup.launch wheel_type:=WH02
 ```

--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -21,7 +21,7 @@ The package containing default configuration and launch files necessary to start
 - `panther_common_config_file` [*string*, default=**$(find panther_bringup)/config/panther_common.yaml**]: path to yaml file with standard parameters used by the `driver_node`.
 - `panther_version` [*float*, default=**1.0**]: robot version parsed using `PANTHER_ROBOT_VERSION` enironmental variable.
 - `publish_robot_state` [*bool*, default=**true**]: whether to publish default Panther robot description.
-- `robot_description` [*string*]: robot description in URDF format, by default parsed from **$(find panther_description)/urdf/panther.urdf.xacro**, with `wheel_config_path` specified by `wheel_config_file` launch argument and imu position parsed using `PANTHER_IMU_LOCALIZATION_X/Y/Z` and `PANTHER_IMU_ORIENTATION_R/P/Y` evironmental variables.
+- `robot_description` [*string*]: robot description in URDF format, parsed by default from **$(find panther_description)/urdf/panther.urdf.xacro**. URDF itself contains its own arguments that are responsible for wheel selection and imu position.
 - `shutdown_hosts_config_file` [*string*, default=**$(find panther_bringup)/config/shutdown_hosts.yaml**]: path to YAML file with description of hosts to shutdown.
 - `test_animations` [*bool*, default=**false**]: enables service `/panther/lights/controller/set/image_animation` allowing to test animations based on provided images.
 - `user_animations_file` [*string*, default=**None**]: optional parameter with path to yaml file with user defined animations. 

--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -1,6 +1,6 @@
 # panther_bringup
 
-Package containing default config and launch files, necessary to  start all base functionalities of the Husarion Panther robot.
+The package containing default configuration and launch files necessary to start all basic functionalities of the Husarion Panther robot.
 
 ## Default nodes launched
 

--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -4,14 +4,14 @@ Package containing default config and launch files, necessary to  start all base
 
 ## Default nodes launched
 
-- `battery_node` - node responsible for monitoring and publishing internal battery state of the Husarion Panther robot. For more information refer to: [panther_battery](/panther_ros/panther_battery/README.md).
+- `battery_node` - node responsible for monitoring and publishing internal battery state of the Husarion Panther robot. For more information refer to: [panther_battery](../panther_battery/README.md).
 - `imu_manager` - nodelet managing Phidget Spatial IMU sensor.
-- `lights_driver_node` - node responsible for displaying frames on the Husarion Panther robot LED panels. For more information refer to: [panther_lights](/panther_ros/panther_lights/README.md).
-- `lights_controller_node` - node responsible for processing animations and publishing frames to be displayed on the Husarion Panther robot LED panels. For more information refer to: [panther_lights](/panther_ros/panther_lights/README.md).
-- `manager_bt_node` - node responsible for managing the Husarion Panther robot. Designs a system handling LED panels, safety features and software shutdown of components. For more information refer to: [panther_manager](/panther_ros/panther_manager/README.md).
-- `panther_driver` - node responsible for communication with motor controllers and computing inverse and forward kinematics of a robot. For more information refer to: [panther_driver](/panther_ros/panther_driver/README.md).
-- `power_control`  - node responsible for power management of the Husarion Panther robot. For more information refer to: [panther_power_control](/panther_ros/panther_power_control/README.md).
-- `robot_state_publisher` - node publishing description of the Husarion Panther robot. For more information refer to: [panther_description](/panther_ros/panther_description/README.md).
+- `lights_driver_node` - node responsible for displaying frames on the Husarion Panther robot LED panels. For more information refer to: [panther_lights](../panther_lights/README.md).
+- `lights_controller_node` - node responsible for processing animations and publishing frames to be displayed on the Husarion Panther robot LED panels. For more information refer to: [panther_lights](../panther_lights/README.md).
+- `manager_bt_node` - node responsible for managing the Husarion Panther robot. Designs a system handling LED panels, safety features and software shutdown of components. For more information refer to: [panther_manager](../panther_manager/README.md).
+- `panther_driver` - node responsible for communication with motor controllers and computing inverse and forward kinematics of a robot. For more information refer to: [panther_driver](../panther_driver/README.md).
+- `power_control`  - node responsible for power management of the Husarion Panther robot. For more information refer to: [panther_power_control](../panther_power_control/README.md).
+- `robot_state_publisher` - node publishing description of the Husarion Panther robot. For more information refer to: [panther_description](../panther_description/README.md).
 
 ## Launch arguments
 

--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -10,7 +10,7 @@ The package containing default configuration and launch files necessary to start
 - `lights_controller_node` - node responsible for processing animations and publishing frames to be displayed on the Husarion Panther robot LED panels. For more information refer to: [panther_lights](../panther_lights/README.md).
 - `manager_bt_node` - node responsible for managing the Husarion Panther robot. Designs a system handling LED panels, safety features and software shutdown of components. For more information refer to: [panther_manager](../panther_manager/README.md).
 - `panther_driver` - node responsible for communication with motor controllers and computing inverse and forward kinematics of a robot. For more information refer to: [panther_driver](../panther_driver/README.md).
-- `power_control`  - node responsible for power management of the Husarion Panther robot. For more information refer to: [panther_power_control](../panther_power_control/README.md).
+- `power_control` - node responsible for power management of the Husarion Panther robot. For more information refer to: [panther_power_control](../panther_power_control/README.md).
 - `robot_state_publisher` - node publishing description of the Husarion Panther robot. For more information refer to: [panther_description](../panther_description/README.md).
 
 ## Launch arguments

--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -23,7 +23,7 @@ The package containing default configuration and launch files necessary to start
 - `publish_robot_state` [*bool*, default=**true**]: whether to publish default Panther robot description.
 - `robot_description` [*string*]: robot description in URDF format, by default parsed from **$(find panther_description)/urdf/panther.urdf.xacro**, with `wheel_config_path` specified by `wheel_config_file` launch argument and imu position parsed using `PANTHER_IMU_LOCALIZATION_X/Y/Z` and `PANTHER_IMU_ORIENTATION_R/P/Y` evironmental variables.
 - `shutdown_hosts_config_file` [*string*, default=**$(find panther_bringup)/config/shutdown_hosts.yaml**]: path to YAML file with description of hosts to shutdown.
-- `test_animations` [*bool*, default=**false**]: if true then something but i forgot what at this point
+- `test_animations` [*bool*, default=**false**]: enables service `/panther/lights/controller/set/image_animation` allowing to test animations based on provided images.
 - `user_animations_file` [*string*, default=**None**]: optional parameter with path to yaml file with user defined animations. 
 - `wheel_config_file` [*string*, default=**$(find panther_description)/config/WH01.yaml**]: path to YAML file with wheel specyfication. value of this argument depends on `wheel_type` launch argument.
 - `wheel_type` [*string*, default=**WH01**]: type of wheel, possible are: **WH01** - offroad, **WH02** - mecanum, **WH04** - small pneumatic, **custom** - custom wheel type (requires setting `wheel_config_file` argument accordingly).

--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -1,3 +1,30 @@
 # panther_bringup
 
 Package containing default config and launch files, necessary to  start all base functionalities of the Husarion Panther robot.
+
+## Default nodes launched
+
+- `battery_node` - node responsible for monitoring and publishing internal battery state of the Husarion Panther robot. For more information refer to: [panther_battery](/panther_ros/panther_battery/README.md).
+- `imu_manager` - nodelet managing Phidget Spatial IMU sensor.
+- `lights_driver_node` - node responsible for displaying frames on the Husarion Panther robot LED panels. For more information refer to: [panther_lights](/panther_ros/panther_lights/README.md).
+- `lights_controller_node` - node responsible for processing animations and publishing frames to be displayed on the Husarion Panther robot LED panels. For more information refer to: [panther_lights](/panther_ros/panther_lights/README.md).
+- `manager_bt_node` - node responsible for managing the Husarion Panther robot. Designs a system handling LED panels, safety features and software shutdown of components. For more information refer to: [panther_manager](/panther_ros/panther_manager/README.md).
+- `panther_driver` - node responsible for communication with motor controllers and computing inverse and forward kinematics of a robot. For more information refer to: [panther_driver](/panther_ros/panther_driver/README.md).
+- `power_control`  - node responsible for power management of the Husarion Panther robot. For more information refer to: [panther_power_control](/panther_ros/panther_power_control/README.md).
+- `robot_state_publisher` - node publishing description of the Husarion Panther robot. For more information refer to: [panther_description](/panther_ros/panther_description/README.md).
+
+## Launch arguments
+
+- `bt_project_file` [*string*, default=**$(find panther_manager)/config/Panther106BT.btproj**]: path to BehaviorTree project used by `panther_manager`. Default value of this parameter depends on `panther_version` argument. For version 1.2 and above it is: **(find panther_manager)/config/Panther106BT.btproj**.
+- `disable_manager` [*bool*, default=**false**]: allows to disable `panther_manager`, used for testing purposes.
+- `namespace` [*string*, default=**panther**]: namespace to use with robot.
+- `panther_common_config_file` [*string*, default=**$(find panther_bringup)/config/panther_common.yaml**]: path to yaml file with standard parameters used by the `driver_node`.
+- `panther_version` [*float*, default=**1.0**]: robot version parsed using `PANTHER_ROBOT_VERSION` enironmental variable.
+- `publish_robot_state` [*bool*, default=**true**]: whether to publish default Panther robot description.
+- `robot_description` [*string*]: robot description in URDF format, by default parsed from **$(find panther_description)/urdf/panther.urdf.xacro**, with `wheel_config_path` specified by `wheel_config_file` launch argument and imu position parsed using `PANTHER_IMU_LOCALIZATION_X/Y/Z` and `PANTHER_IMU_ORIENTATION_R/P/Y` evironmental variables.
+- `shutdown_hosts_config_file` [*string*, default=**$(find panther_bringup)/config/shutdown_hosts.yaml**]: path to YAML file with description of hosts to shutdown.
+- `test_animations` [*bool*, default=**false**]: if true then something but i forgot what at this point
+- `user_animations_file` [*string*, default=**None**]: optional parameter with path to yaml file with user defined animations. 
+- `wheel_config_file` [*string*, default=**$(find panther_description)/config/WH01.yaml**]: path to YAML file with wheel specyfication. value of this argument depends on `wheel_type` launch argument.
+- `wheel_type` [*string*, default=**WH01**]: type of wheel, possible are: **WH01** - offroad, **WH02** - mecanum, **WH04** - small pneumatic, **custom** - custom wheel type (requires setting `wheel_config_file` argument accordingly).
+

--- a/panther_driver/README.md
+++ b/panther_driver/README.md
@@ -55,4 +55,4 @@ For a `/joint_states` message is carrying given data:
 
 #### Kinematics type - explanation
 
-The Panther robot can be configured with different wheels to match your needs, we provide 2 different kinematics types `differential`/`mecanum`. You can change the wheel type by providing an appropriate launch parameter with a path to the wheel configuration file - `wheel_config_file`. Basic wheel configuration files (*WH01.yaml, WH04.yaml*): are located in `panther_description` package.
+The Panther robot can be configured with different wheels to match your needs, we provide 2 different kinematics types `differential`/`mecanum`. You can change the wheel type by providing an appropriate launch parameter with a path to the wheel configuration file - `wheel_config_file`. Basic wheel configuration files (*WH01.yaml, WH02.yaml, WH04.yaml*): are located in `panther_description` package.


### PR DESCRIPTION
bump::patch

This suppose to be just update of panther_bringup README, but I also added info in main README about providing custom robot description as it is kind of related to panther_bringup launch arguments. Plus small fix in driver docs.
Some of information (manager behavior tree) are ahead of time - they are supposed to be merged in close future, IMO there is no point in writing info and correcting it two weeks later. 