### PR TITLE
ROS 1 Fix BT node throwing wrong error

### DIFF
--- a/panther_manager/plugins/decorator/tick_after_timeout_node.cpp
+++ b/panther_manager/plugins/decorator/tick_after_timeout_node.cpp
@@ -20,7 +20,7 @@ BT::NodeStatus TickAfterTimeout::tick()
 {
   float timeout;
   if (!getInput<float>("timeout", timeout)) {
-    throw("[", name(), "] Failed to get input [timeout]");
+    throw(BT::RuntimeError("[", name(), "] Failed to get input [timeout]"));
   }
   timeout_ = ros::Duration(timeout);
 


### PR DESCRIPTION
bump::patch

Fix TickAfterTimeout BT node not throwing correct error.
