### PR TITLE
Fix CAN communication error check

### DIFF
--- a/panther_driver/src/panther_can.py
+++ b/panther_driver/src/panther_can.py
@@ -72,7 +72,7 @@ class PantherCAN:
         for controller in self._motor_controllers:
             if self._robot_driver_initialized:
                 faults = [
-                    time_now - cb_time > rospy.Duration(0.5)
+                    time_now - cb_time > rospy.Duration(0.2)
                     for cb_time in controller.last_time_callback.values()
                 ]
                 yield any(faults)


### PR DESCRIPTION
`bump::patch`

## Description

The timeout configuration in the CANOpen Python library was initially set to approximately 0.3 seconds, while the timeout within the driver communication sequence was established at 0.5 seconds. As a result, the error occurrence exhibited a sporadic nature, alternating between true and false states. To address this, an adjustment was made to the CAN network communication timeout, reducing it from 0.5 seconds to 0.2 seconds for improved reliability and consistency.

However, there still exists an ongoing issue whereby an error in the rear controller will subsequently trigger an error in the front controller. This phenomenon arises due to a timeout mechanism, which, in the event of communication issues within one channel, leads to a suspension of communication on the second channel, consequently resulting in the expiration of the timeout period. In my view, within the current implementation, there lacks a robust approach to circumvent this challenge.