### PR TITLE
fix bat temp and voltage on /battery topic

### DIFF
--- a/panther_battery/src/adc_node.py
+++ b/panther_battery/src/adc_node.py
@@ -141,8 +141,8 @@ class ADCNode:
 
             self._publish_battery_msg(
                 self._battery_pub,
-                (V_bat_1 + V_bat_2) / 2.0,
-                (temp_bat_1 + temp_bat_2) / 2.0,
+                max(V_bat_1, V_bat_2),
+                max(temp_bat_1, temp_bat_2),
                 -(I_bat_1 + I_bat_2) + I_charge_bat_1 + I_charge_bat_2,
                 I_charge_bat_1 + I_charge_bat_2,
             )


### PR DESCRIPTION
`bump::patch`

## Description 

Due to the fact that the data on the /battery topic is used for diagnostics, which take place in the manager_node, the method of their calculation has been changed. The value of battery temperature and voltage has been altered from the average to the maximum among the two channels.

Related PR:
#177 
