### PR TITLE
ROS 2 - Fix estop threads

### DIFF
--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/gpio_controller.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/gpio_controller.hpp
@@ -34,10 +34,10 @@
 namespace panther_hardware_interfaces
 {
 
-class e_stop_reset_interrupted : public std::exception
+class EStopResetInterrupted : public std::exception
 {
 public:
-  e_stop_reset_interrupted(const std::string & message) : msg_(message) {}
+  EStopResetInterrupted(const std::string & message) : msg_(message) {}
   const char * what() const noexcept override { return msg_.c_str(); }
 
 private:
@@ -223,6 +223,17 @@ protected:
   std::unique_ptr<Watchdog> watchdog_;
 
 private:
+  /**
+   * @brief Waits for a specific duration or until an interruption is signaled.
+   *
+   * This method is designed to block execution for the specified timeout duration. It also monitors
+   * for an interruption signal which, if received, will cause the method to return early. The
+   * interruption is controlled by the `should_abort_e_stop_reset_` flag.
+   *
+   * @param timeout Duration to wait for in milliseconds.
+   * @return `true` if the wait completed without interruption, `false` if an interruption was
+   * signaled.
+   */
   bool WaitFor(std::chrono::milliseconds timeout);
 
   /**

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/gpio_controller.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/gpio_controller.hpp
@@ -37,7 +37,7 @@ namespace panther_hardware_interfaces
 class e_stop_reset_interrupted : public std::exception
 {
 public:
-  e_stop_reset_interrupted(const std::string & message = "") : msg_(message) {}
+  e_stop_reset_interrupted(const std::string & message) : msg_(message) {}
   const char * what() const noexcept override { return msg_.c_str(); }
 
 private:

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system.hpp
@@ -147,7 +147,7 @@ protected:
   float panther_version_;
 
   std::atomic_bool e_stop_ = true;
-  std::atomic_bool use_can_for_e_stop_reset_ = false;
+  std::atomic_bool use_can_for_e_stop_trigger_ = false;
   std::atomic_bool last_commands_zero_ = false;
   std::mutex e_stop_manipulation_mtx_;
   std::mutex motor_controller_write_mtx_;

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system.hpp
@@ -147,6 +147,7 @@ protected:
   float panther_version_;
 
   std::atomic_bool e_stop_ = true;
+  std::atomic_bool use_can_for_e_stop_reset_ = false;
   std::atomic_bool last_commands_zero_ = false;
   std::mutex e_stop_manipulation_mtx_;
   std::mutex motor_controller_write_mtx_;

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system_ros_interface.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system_ros_interface.hpp
@@ -96,6 +96,8 @@ public:
    * @param node The shared pointer to the ROS node under which the service will be advertised.
    * @param service_name The name of the service. This is the name under which the service will be
    * advertised over ROS.
+   * @param group The shared pointer to the node's callback group. Defaults to nullptr, which
+   * indicates that the node's default callback group will be used.
    */
   void RegisterService(
     const rclcpp::Node::SharedPtr node, const std::string & service_name,
@@ -167,17 +169,18 @@ public:
    * @param group_id An unsigned integer representing the unique identifier of the callback group
    * that the service should be associated with. A value of '0' indicates that the service should
    * use the default node callback group.
-   * @param callback_group_t The type of the callback group to be used, expressed as an enumerated
-   * value of `rclcpp::CallbackGroupType`. If a new group must be created, this specifies whether
-   * it should be `MutuallyExclusive` or `Reentrant`. The default value is `MutuallyExclusive`.
+   * @param callback_group_type The type of the callback group to be used, expressed as an
+   * enumerated value of `rclcpp::CallbackGroupType`. If a new group must be created, this specifies
+   * whether it should be `MutuallyExclusive` or `Reentrant`. The default value is
+   * `MutuallyExclusive`.
    */
   template <class SrvT, class CallbackT>
   inline void AddService(
     const std::string & service_name, const CallbackT & callback, const unsigned group_id = 0,
-    rclcpp::CallbackGroupType callback_group_t = rclcpp::CallbackGroupType::MutuallyExclusive)
+    rclcpp::CallbackGroupType callback_group_type = rclcpp::CallbackGroupType::MutuallyExclusive)
   {
     rclcpp::CallbackGroup::SharedPtr callback_group = GetOrCreateNodeCallbackGroup(
-      group_id, callback_group_t);
+      group_id, callback_group_type);
 
     auto wrapper = std::make_shared<ROSServiceWrapper<SrvT, CallbackT>>(callback);
     wrapper->RegisterService(node_, service_name, callback_group);
@@ -248,18 +251,18 @@ private:
    * @brief Retrieves an existing callback group from the internal map or creates
    * a new one if it does not exist.
    *
-   * When the `group_id` is set to 0 and the `callback_group_t` is set to `MutuallyExclusive`, the
-   * method returns a `nullptr`, indicating the usage of the default node callback group.
+   * When the `group_id` is set to 0 and the `callback_group_type` is set to `MutuallyExclusive`,
+   * the method returns a `nullptr`, indicating the usage of the default node callback group.
    *
    * @param group_id The numeric identifier of the callback group. If set to 0, the default
    * node callback group is used.
-   * @param callback_group_t The type of the callback group, defined by the
+   * @param callback_group_type The type of the callback group, defined by the
    * `rclcpp::CallbackGroupType` enumeration.
    * @return Shared pointer to the requested callback group, or `nullptr` if the default node
    * callback group is to be used.
    */
   rclcpp::CallbackGroup::SharedPtr GetOrCreateNodeCallbackGroup(
-    const unsigned group_id, rclcpp::CallbackGroupType callback_group_t);
+    const unsigned group_id, rclcpp::CallbackGroupType callback_group_type);
 
   rclcpp::Node::SharedPtr node_;
   std::unordered_map<unsigned, rclcpp::CallbackGroup::SharedPtr> callback_groups_;

--- a/panther_hardware_interfaces/src/gpio_controller.cpp
+++ b/panther_hardware_interfaces/src/gpio_controller.cpp
@@ -133,13 +133,13 @@ void GPIOControllerPTH12X::EStopReset()
 
   if (!WaitFor(std::chrono::milliseconds(100))) {
     gpio_driver_->ChangePinDirection(e_stop_pin, gpiod::line::direction::INPUT);
-    throw e_stop_reset_interrupted("E-stop reset interrupted after setting pin high.");
+    throw EStopResetInterrupted("E-stop reset interrupted after setting pin high.");
   }
 
   gpio_driver_->ChangePinDirection(e_stop_pin, gpiod::line::direction::INPUT);
 
   if (!WaitFor(std::chrono::milliseconds(100))) {
-    throw e_stop_reset_interrupted("E-stop reset interrupted after setting pin high.");
+    throw EStopResetInterrupted("E-stop reset interrupted after setting pin high.");
   }
 
   e_stop_state = !gpio_driver_->IsPinActive(e_stop_pin);

--- a/panther_hardware_interfaces/src/gpio_controller.cpp
+++ b/panther_hardware_interfaces/src/gpio_controller.cpp
@@ -222,7 +222,12 @@ void GPIOControllerPTH10X::Start()
   gpio_driver_->SetPinValue(panther_gpiod::GPIOPin::MOTOR_ON, true);
 }
 
-void GPIOControllerPTH10X::EStopTrigger() {}
+void GPIOControllerPTH10X::EStopTrigger()
+{
+  throw std::runtime_error(
+    "This robot version does not support this functionality. Trying to set safety stop using CAN "
+    "command.");
+}
 
 void GPIOControllerPTH10X::EStopReset()
 {

--- a/panther_hardware_interfaces/src/gpio_controller.cpp
+++ b/panther_hardware_interfaces/src/gpio_controller.cpp
@@ -206,8 +206,8 @@ void GPIOControllerPTH12X::InterruptEStopReset()
 bool GPIOControllerPTH12X::WaitFor(std::chrono::milliseconds timeout)
 {
   std::unique_lock<std::mutex> lck(e_stop_cv_mtx_);
-  should_abort_e_stop_reset_ = false;
 
+  should_abort_e_stop_reset_ = false;
   bool interrupted = e_stop_cv_.wait_for(
     lck, timeout, [&]() { return should_abort_e_stop_reset_; });
 

--- a/panther_hardware_interfaces/src/panther_system.cpp
+++ b/panther_hardware_interfaces/src/panther_system.cpp
@@ -712,7 +712,7 @@ void PantherSystem::ResetEStop()
 
     try {
       gpio_controller_->EStopReset();
-    } catch (const e_stop_reset_interrupted & e) {
+    } catch (const EStopResetInterrupted & e) {
       RCLCPP_INFO(logger_, "E-stop reset has been interrupted");
       return;
     } catch (const std::runtime_error & e) {

--- a/panther_hardware_interfaces/src/panther_system.cpp
+++ b/panther_hardware_interfaces/src/panther_system.cpp
@@ -676,7 +676,7 @@ void PantherSystem::SetEStop()
   try {
     gpio_controller_->EStopTrigger();
   } catch (const std::runtime_error & e) {
-    RCLCPP_ERROR_STREAM(logger_, "Error when trying to set E-stop using GPIO: " << e.what());
+    RCLCPP_INFO_STREAM(logger_, "Trying to set E-stop using GPIO: " << e.what());
     gpio_controller_error = true;
   }
 

--- a/panther_hardware_interfaces/src/panther_system.cpp
+++ b/panther_hardware_interfaces/src/panther_system.cpp
@@ -153,9 +153,11 @@ CallbackReturn PantherSystem::on_activate(const rclcpp_lifecycle::State &)
     std::bind(&PantherSystem::MotorsPowerEnable, this, std::placeholders::_1));
 
   panther_system_ros_interface_->AddService<TriggerSrv, std::function<void()>>(
-    "~/e_stop_trigger", std::bind(&PantherSystem::SetEStop, this));
+    "~/e_stop_trigger", std::bind(&PantherSystem::SetEStop, this), 1,
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   panther_system_ros_interface_->AddService<TriggerSrv, std::function<void()>>(
-    "~/e_stop_reset", std::bind(&PantherSystem::ResetEStop, this));
+    "~/e_stop_reset", std::bind(&PantherSystem::ResetEStop, this), 2,
+    rclcpp::CallbackGroupType::MutuallyExclusive);
 
   panther_system_ros_interface_->AddDiagnosticTask(
     std::string("system errors"), this, &PantherSystem::DiagnoseErrors);

--- a/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
+++ b/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
@@ -258,10 +258,10 @@ bool PantherSystemRosInterface::UpdateIOStateMsg(
 }
 
 rclcpp::CallbackGroup::SharedPtr PantherSystemRosInterface::GetOrCreateNodeCallbackGroup(
-  const unsigned group_id, rclcpp::CallbackGroupType callback_group_t)
+  const unsigned group_id, rclcpp::CallbackGroupType callback_group_type)
 {
   if (group_id == 0) {
-    if (callback_group_t == rclcpp::CallbackGroupType::Reentrant) {
+    if (callback_group_type == rclcpp::CallbackGroupType::Reentrant) {
       throw std::runtime_error(
         "Node callback group with id 0 (default group) cannot be of "
         "rclcpp::CallbackGroupType::Reentrant type.");
@@ -271,14 +271,14 @@ rclcpp::CallbackGroup::SharedPtr PantherSystemRosInterface::GetOrCreateNodeCallb
 
   auto search = callback_groups_.find(group_id);
   if (search != callback_groups_.end()) {
-    if (search->second->type() == callback_group_t) {
+    if (search->second->type() == callback_group_type) {
       return search->second;
     } else {
       throw std::runtime_error("Requested node callback group has incorrect type.");
     }
   }
 
-  auto callback_group = node_->create_callback_group(callback_group_t);
+  auto callback_group = node_->create_callback_group(callback_group_type);
   callback_groups_[group_id] = callback_group;
   return callback_group;
 }

--- a/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
+++ b/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
@@ -100,15 +100,6 @@ PantherSystemRosInterface::PantherSystemRosInterface(
 
 PantherSystemRosInterface::~PantherSystemRosInterface()
 {
-  realtime_driver_state_publisher_.reset();
-  driver_state_publisher_.reset();
-  realtime_io_state_publisher_.reset();
-  io_state_publisher_.reset();
-  realtime_e_stop_state_publisher_.reset();
-  e_stop_state_publisher_.reset();
-
-  service_wrappers_storage_.clear();
-
   if (executor_) {
     executor_->cancel();
 
@@ -118,6 +109,15 @@ PantherSystemRosInterface::~PantherSystemRosInterface()
 
     executor_.reset();
   }
+
+  realtime_driver_state_publisher_.reset();
+  driver_state_publisher_.reset();
+  realtime_io_state_publisher_.reset();
+  io_state_publisher_.reset();
+  realtime_e_stop_state_publisher_.reset();
+  e_stop_state_publisher_.reset();
+
+  service_wrappers_storage_.clear();
 
   node_.reset();
 }
@@ -269,13 +269,12 @@ rclcpp::CallbackGroup::SharedPtr PantherSystemRosInterface::GetOrCreateNodeCallb
     return nullptr;  // default node callback group
   }
 
-  auto search = callback_groups_.find(group_id);
+  const auto search = callback_groups_.find(group_id);
   if (search != callback_groups_.end()) {
-    if (search->second->type() == callback_group_type) {
-      return search->second;
-    } else {
+    if (search->second->type() != callback_group_type) {
       throw std::runtime_error("Requested node callback group has incorrect type.");
     }
+    return search->second;
   }
 
   auto callback_group = node_->create_callback_group(callback_group_type);


### PR DESCRIPTION
## Changes

- During EStop triggering, CAN communication is only used if GPIO pin manipulation fails,
- The single-thread executor has been replaced with a multi-threaded one, enabling simultaneous handling of the `e_stop_trigger` and `e_stop_reset` services. This has helped to implement behavior where the trigger has a higher "priority" than the reset, ensuring that each trigger is immediate (unlike before, where it had to wait max. 200ms for the reset to complete). These changes should guarantee thread safety. The rest of the services are still managed in the node's default callback group, so they are not executed concurrently.