### PR TITLE
Manager launch fix

### DIFF
--- a/panther_bringup/launch/bringup.launch.py
+++ b/panther_bringup/launch/bringup.launch.py
@@ -307,7 +307,7 @@ def generate_launch_description():
                 ]
             )
         ),
-        condition=UnlessCondition(use_sim) and UnlessCondition(disable_manager),
+        condition=UnlessCondition(PythonExpression([use_sim, " or ", disable_manager])),
         launch_arguments={
             "namespace": namespace,
             "panther_version": panther_version,


### PR DESCRIPTION
Fix `not None obj` and `not None obj` => always True
![image](https://github.com/husarion/panther_ros/assets/126687345/455e5009-265a-4639-b95b-b2a14258d46f)
