### PR TITLE
Removed test with wrong imu sensor name

### DIFF
--- a/panther_hardware_interfaces/test/test_panther_imu.cpp
+++ b/panther_hardware_interfaces/test/test_panther_imu.cpp
@@ -356,13 +356,10 @@ TEST_F(TestPantherImuSensor, CheckSensorName)
   EXPECT_THROW({ imu_sensor_->CheckSensorName(); }, std::runtime_error);
 
   hardware_interface::ComponentInfo sensor_info;
-  sensor_info.name = "wrong_imu";
+  sensor_info.name = "imu";
   info.sensors.push_back(sensor_info);
   imu_sensor_->SetHardwareInfo(info);
-  EXPECT_THROW({ imu_sensor_->CheckSensorName(); }, std::runtime_error);
 
-  info.sensors.front().name = "imu";
-  imu_sensor_->SetHardwareInfo(info);
   EXPECT_NO_THROW({ imu_sensor_->CheckSensorName(); });
 }
 


### PR DESCRIPTION
After https://github.com/husarion/panther_ros/pull/304 checking wrong  imu sensor name test is unnecessary.

Before:
```
[ RUN      ] TestPantherImuSensor.CheckSensorName
/home/deli/Documents/panther_dev/panther_ros/panther_hardware_interfaces/test/test_panther_imu.cpp:362: Failure
Expected: { imu_sensor_->CheckSensorName(); } throws an exception of type std::runtime_error.
  Actual: it throws nothing.
[  FAILED  ] TestPantherImuSensor.CheckSensorName (6 ms)
```
After:
```
[ RUN      ] TestPantherImuSensor.CheckSensorName
[       OK ] TestPantherImuSensor.CheckSensorName (6 ms)
```