### PR TITLE
added diagnostics remapping and namespace to system_status

### DIFF
--- a/panther_battery/launch/battery.launch.py
+++ b/panther_battery/launch/battery.launch.py
@@ -37,6 +37,7 @@ def generate_launch_description():
         name="battery_node",
         parameters=[{"panther_version": panther_version}],
         namespace=namespace,
+        remappings=[("/diagnostics", "diagnostics")],
     )
 
     actions = [

--- a/panther_bringup/launch/bringup.launch.py
+++ b/panther_bringup/launch/bringup.launch.py
@@ -241,6 +241,8 @@ def generate_launch_description():
         name="system_status",
         output="screen",
         condition=UnlessCondition(use_sim),
+        namespace=namespace,
+        remappings=[("/diagnostics", "diagnostics")],
     )
 
     lights_launch = IncludeLaunchDescription(

--- a/panther_controller/launch/controller.launch.py
+++ b/panther_controller/launch/controller.launch.py
@@ -154,6 +154,7 @@ def generate_launch_description():
         parameters=[robot_description, controller_config_path],
         namespace=namespace,
         remappings=[
+            ("/diagnostics", "diagnostics"),
             (
                 "panther_system_node/driver/motor_controllers_state",
                 "driver/motor_controllers_state",

--- a/panther_lights/launch/lights.launch.py
+++ b/panther_lights/launch/lights.launch.py
@@ -47,6 +47,7 @@ def generate_launch_description():
         executable="driver_node",
         name="lights_driver_node",
         namespace=namespace,
+        remappings=[("/diagnostics", "diagnostics")],
         on_exit=Shutdown(),
     )
 


### PR DESCRIPTION
```bash
husarion@panther-1502-rpi:~$ ros2 topic list
/panther/battery
/panther/battery_1_raw
/panther/cmd_vel
/panther/diagnostics
/panther/driver/motor_controllers_state
/panther/dynamic_joint_states
/panther/ekf_node/set_pose
/panther/hardware/e_stop
/panther/hardware/io_state
/panther/imu/data
/panther/imu_broadcaster/imu
/panther/imu_broadcaster/transition_event
/panther/joint_state_broadcaster/transition_event
/panther/joint_states
/panther/lights/driver/channel_1_frame
/panther/lights/driver/channel_2_frame
/panther/odom/wheels
/panther/odometry/filtered
/panther/panther_base_controller/transition_event
/panther/robot_description
/panther/system_status
/parameter_events
/rosout
/tf
/tf_static
```

Added namespaces to all `diagnostics` topics.