### PR TITLE
Cleaned up VCS repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,7 @@ source install/setup.bash
 Real robot:
 
 ```bash
-ros2 launch panther_bringup bringup.launch.pyvcs import src < src/panther_ros/panther/panther_$HUSARION_ROS_BUILD_TYPE.repos
-
-cp -r src/ros2_controllers/diff_drive_controller src
-cp -r src/ros2_controllers/imu_sensor_broadcaster src
-rm -rf src/ros2_controllers
-
-sudo rosdep init
-rosdep update --rosdistro $ROS_DISTRO
-rosdep install --from-paths src -y -i
-
-source /opt/ros/$ROS_DISTRO/setup.bash
-colcon build --symlink-install --packages-up-to panther --cmake-args -DCMAKE_BUILD_TYPE=Release
-
-source install/setup.bash
+ros2 launch panther_bringup bringup.launch.py
 ```
 
 Simulation:

--- a/README.md
+++ b/README.md
@@ -33,10 +33,7 @@ export HUSARION_ROS_BUILD_TYPE=simulation
 ### Build
 
 ``` bash
-vcs import src < src/panther_ros/panther/panther_hardware.repos
-if [ "$HUSARION_ROS_BUILD_TYPE" == "simulation" ]; then
-  vcs import src < src/panther_ros/panther/panther_simulation.repos
-fi
+vcs import src < src/panther_ros/panther/panther_$HUSARION_ROS_BUILD_TYPE.repos
 
 cp -r src/ros2_controllers/diff_drive_controller src
 cp -r src/ros2_controllers/imu_sensor_broadcaster src
@@ -60,7 +57,20 @@ source install/setup.bash
 Real robot:
 
 ```bash
-ros2 launch panther_bringup bringup.launch.py
+ros2 launch panther_bringup bringup.launch.pyvcs import src < src/panther_ros/panther/panther_$HUSARION_ROS_BUILD_TYPE.repos
+
+cp -r src/ros2_controllers/diff_drive_controller src
+cp -r src/ros2_controllers/imu_sensor_broadcaster src
+rm -rf src/ros2_controllers
+
+sudo rosdep init
+rosdep update --rosdistro $ROS_DISTRO
+rosdep install --from-paths src -y -i
+
+source /opt/ros/$ROS_DISTRO/setup.bash
+colcon build --symlink-install --packages-up-to panther --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+source install/setup.bash
 ```
 
 Simulation:

--- a/panther/panther_hardware.repos
+++ b/panther/panther_hardware.repos
@@ -18,4 +18,4 @@ repositories:
   ros2_controllers: # Caused by two error: 1. https://github.com/ros-controls/ros2_controllers/pull/1104 2. There is no nice way to change `sensor_name` imu_bradcaster param when spawning multiple robots -> ros2_control refer only to single imu entity
     type: git
     url: https://github.com/husarion/ros2_controllers/
-    version: b638a948691c75a1c943debf181b7a0d1b22cb2d
+    version: 9da42a07a83bbf3faf5cad11793fff22f25068af

--- a/panther/panther_hardware.repos
+++ b/panther/panther_hardware.repos
@@ -6,20 +6,16 @@ repositories:
   husarion_controllers:
     type: git
     url: https://github.com/husarion/husarion_controllers
-    version: main
+    version: 217b09830f5f42930098b9992eda41710702b625
   panther_msgs:
     type: git
     url: https://github.com/husarion/panther_msgs.git
-    version: ros2
-  robot_localization: # Caused by this error https://github.com/cra-ros-pkg/robot_localization/pull/876, it can be removed after the next synchronization of apt packages.
-    type: git
-    url: https://github.com/cra-ros-pkg/robot_localization.git
-    version: humble-devel
+    version: c80a3da24dae9a1fab0559d5de687b73d755f6f5
   ros_components_description:
     type: git
     url: https://github.com/husarion/ros_components_description.git
-    version: ros2
+    version: f50cee03b163120071e38d7b70f39befd9320a33
   ros2_controllers: # Caused by two error: 1. https://github.com/ros-controls/ros2_controllers/pull/1104 2. There is no nice way to change `sensor_name` imu_bradcaster param when spawning multiple robots -> ros2_control refer only to single imu entity
     type: git
-    url: https://github.com/rafal-gorecki/ros2_controllers.git
-    version: humble
+    url: https://github.com/husarion/ros2_controllers/
+    version: b638a948691c75a1c943debf181b7a0d1b22cb2d

--- a/panther/panther_simulation.repos
+++ b/panther/panther_simulation.repos
@@ -18,7 +18,7 @@ repositories:
   ros2_controllers: # Caused by two error: 1. https://github.com/ros-controls/ros2_controllers/pull/1104 2. There is no nice way to change `sensor_name` imu_bradcaster param when spawning multiple robots -> ros2_control refer only to single imu entity
     type: git
     url: https://github.com/husarion/ros2_controllers/
-    version: b638a948691c75a1c943debf181b7a0d1b22cb2d
+    version: 9da42a07a83bbf3faf5cad11793fff22f25068af
   husarion_gz_worlds:
     type: git
     url: https://github.com/husarion/husarion_gz_worlds.git

--- a/panther/panther_simulation.repos
+++ b/panther/panther_simulation.repos
@@ -1,5 +1,25 @@
 repositories:
+  behaviortree_ros2:
+    type: git
+    url: https://github.com/BehaviorTree/BehaviorTree.ROS2
+    version: ce923e19c12d28f4734a41b1442c123f2d4a41d2
+  husarion_controllers:
+    type: git
+    url: https://github.com/husarion/husarion_controllers
+    version: 217b09830f5f42930098b9992eda41710702b625
+  panther_msgs:
+    type: git
+    url: https://github.com/husarion/panther_msgs.git
+    version: c80a3da24dae9a1fab0559d5de687b73d755f6f5
+  ros_components_description:
+    type: git
+    url: https://github.com/husarion/ros_components_description.git
+    version: f50cee03b163120071e38d7b70f39befd9320a33
+  ros2_controllers: # Caused by two error: 1. https://github.com/ros-controls/ros2_controllers/pull/1104 2. There is no nice way to change `sensor_name` imu_bradcaster param when spawning multiple robots -> ros2_control refer only to single imu entity
+    type: git
+    url: https://github.com/husarion/ros2_controllers/
+    version: b638a948691c75a1c943debf181b7a0d1b22cb2d
   husarion_gz_worlds:
     type: git
     url: https://github.com/husarion/husarion_gz_worlds.git
-    version: main
+    version: 3d0b9a084cd22b936af8e2a6df5129d737030afa


### PR DESCRIPTION
waiting on https://github.com/husarion/ros2_controllers/pull/2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified build process by dynamically importing repositories based on `HUSARION_ROS_BUILD_TYPE` variable.

- **Updates**
  - Updated versions for multiple repositories including `husarion_controllers`, `panther_msgs`, `ros_components_description`, and `ros2_controllers` to specific commit hashes.
  - Added new repository `behaviortree_ros2` and updated `husarion_gz_worlds` version.

- **Bug Fixes**
  - Resolved errors related to `ros2_controllers` and `imu_bradcaster` parameter when spawning multiple robots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->