### PR TITLE
ROS 2 remove obsolate tests

### DIFF
--- a/panther_manager/behavior_trees/lights.xml
+++ b/panther_manager/behavior_trees/lights.xml
@@ -49,7 +49,7 @@ current_anim_id = CHARGING_BATTERY_ANIM_ID"/>
                                     param=""
                                     repeating="true"
                                     service_name="lights/controller/set/animation"
-                                    _skipIf="(!e_stop_state) || (current_anim_id == E_STOP_ANIM_ID)"
+                                    _skipIf="(!e_stop_state) || current_anim_id == E_STOP_ANIM_ID"
                                     _onSuccess="current_anim_id = E_STOP_ANIM_ID"/>
         <Sequence name="BatteryStatusSequence">
           <TickAfterTimeout timeout="{LOW_BATTERY_ANIM_PERIOD}"

--- a/panther_manager/test/plugins/test_call_set_bool_service_node.cpp
+++ b/panther_manager/test/plugins/test_call_set_bool_service_node.cpp
@@ -135,22 +135,6 @@ TEST_F(TestCallSetBoolService, WrongSetBoolCallServiceFailure)
   EXPECT_EQ(status, BT::NodeStatus::FAILURE);
 }
 
-TEST_F(TestCallSetBoolService, WrongServiceValueDefined)
-{
-  std::map<std::string, std::string> service = {
-    {"service_name", "set_bool"}, {"data", "wrong_bool"}};
-
-  using std_srvs::srv::SetBool;
-  CreateService<SetBool>(
-    "set_bool",
-    [&](const SetBool::Request::SharedPtr request, SetBool::Response::SharedPtr response) {
-      ServiceCallback(request, response, true, true);
-    });
-  RegisterNodeWithParams<panther_manager::CallSetBoolService>("CallSetBoolService");
-
-  EXPECT_THROW({ CreateTree("CallSetBoolService", service); }, BT::LogicError);
-}
-
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/panther_manager/test/plugins/test_call_set_led_animation_service_node.cpp
+++ b/panther_manager/test/plugins/test_call_set_led_animation_service_node.cpp
@@ -171,26 +171,6 @@ TEST_F(TestCallSetLedAnimationService, WrongSetLedAnimationCallServiceFailure)
   EXPECT_EQ(status, BT::NodeStatus::FAILURE);
 }
 
-TEST_F(TestCallSetLedAnimationService, WrongRepeatingServiceValueDefined)
-{
-  std::map<std::string, std::string> service = {
-    {"service_name", "set_led_animation"}, {"id", "0"}, {"param", ""}, {"repeating", "wrong_bool"}};
-
-  RegisterNodeWithParams<panther_manager::CallSetLedAnimationService>("CallSetLedAnimationService");
-
-  EXPECT_THROW({ CreateTree("CallSetLedAnimationService", service); }, BT::LogicError);
-}
-
-TEST_F(TestCallSetLedAnimationService, WrongIdServiceValueDefined)
-{
-  std::map<std::string, std::string> service = {
-    {"service_name", "set_led_animation"}, {"id", "-5"}, {"param", ""}, {"repeating", "true"}};
-
-  RegisterNodeWithParams<panther_manager::CallSetLedAnimationService>("CallSetLedAnimationService");
-
-  EXPECT_THROW({ CreateTree("CallSetLedAnimationService", service); }, BT::LogicError);
-}
-
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### Description

Remove tests that are no longer necessary. The type mismatch check is performed during tree creation inside factory. This tests do not check any part of our code so there is no point having them. 

Also, remove unnecessary brackets inside `lights.xml`

### Modifications

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified logical expression for setting animations to improve readability.

- **Tests**
  - Removed test cases for incorrect service values to streamline the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->