### PR TITLE
Ros2-gps-ekf

### DIFF
--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -63,7 +63,7 @@ Extended Kalman Filter node for more accurate odometry. For more information, re
 
 [//]: # (ROS_API_NODE_SUBSCRIBERS_START)
 
-- `~/odom/wheels` [*nav_msgs/Odometry*]: robot odometry calculated from wheels.
+- `~/odometry/wheels` [*nav_msgs/Odometry*]: robot odometry calculated from wheels.
 - `~/imu/data` [*sensor_msgs/Imu*]: filtered IMU data.
 - `/tf` [*tf2_msgs/TFMessage*]: transforms of robot system.
 

--- a/panther_controller/README.md
+++ b/panther_controller/README.md
@@ -113,7 +113,7 @@ Controller which manages mobile robots with a differential drive. It converts ve
 
 [//]: # (ROS_API_NODE_PUBLISHERS_START)
 
-- `~/panther_base_controller/odom` [*nav_msgs/msg/Odometry*]: odometry data from wheel encoders.
+- `~/odometry/wheels` [*nav_msgs/msg/Odometry*]: odometry data from wheel encoders.
 
 [//]: # (ROS_API_NODE_PUBLISHERS_END)
 [//]: # (ROS_API_NODE_END)

--- a/panther_controller/launch/controller.launch.py
+++ b/panther_controller/launch/controller.launch.py
@@ -187,7 +187,7 @@ def generate_launch_description():
                 "driver/motor_controllers_state",
             ),
             ("panther_base_controller/cmd_vel_unstamped", "cmd_vel"),
-            ("panther_base_controller/odom", "odom/wheels"),
+            ("panther_base_controller/odom", "odometry/wheels"),
             ("panther_system_node/io_state", "hardware/io_state"),
             ("panther_system_node/e_stop", "hardware/e_stop"),
             ("panther_system_node/e_stop_trigger", "hardware/e_stop_trigger"),

--- a/panther_description/config/components.yaml
+++ b/panther_description/config/components.yaml
@@ -1,25 +1,36 @@
 # By default panther is loaded without any components.
 
-components: []
+# components:
+#   - type: ANT02
+#     parent_link: cover_link
+#     xyz: 0.18 -0.1 0.0
+#     rpy: 0.0 0.0 0.0
+#     device_namespace: gps
+
 
 # If you want to add for example LDR01, LDR06 and CAM01 to your Panther look at this example below:
 
-# components:
-#   - type: LDR01
-#     parent_link: cover_link
-#     xyz: 0.0 0.1 0.0
-#     rpy: 0.0 0.0 0.0
-#     device_namespace: main_lidar
+components:
+  # - type: LDR01
+  #   parent_link: cover_link
+  #   xyz: 0.0 0.1 0.0
+  #   rpy: 0.0 0.0 0.0
+  #   device_namespace: main_lidar
 
-#   - type: LDR06
-#     parent_link: cover_link
-#     xyz: 0.0 -0.1 0.0
-#     rpy: 0.0 0.0 0.0
-#     device_namespace: second_lidar
+  # - type: LDR06
+  #   parent_link: cover_link
+  #   xyz: 0.0 -0.1 0.0
+  #   rpy: 0.0 0.0 0.0
+  #   device_namespace: second_lidar
 
-#   - type: CAM01
-#     name: camera
-#     parent_link: cover_link
-#     xyz: 0.1 0.0 0.0
-#     rpy: 0.0 0.0 0.0
-#     device_namespace: front_cam
+  # - type: CAM01
+  #   name: camera
+  #   parent_link: cover_link
+  #   xyz: 0.1 0.0 0.0
+  #   rpy: 0.0 0.0 0.0
+  #   device_namespace: front_cam
+  - type: ANT02
+    parent_link: cover_link
+    xyz: 0.18 -0.1 0.0
+    rpy: 0.0 0.0 0.0
+    device_namespace: gps

--- a/panther_description/urdf/gazebo.urdf.xacro
+++ b/panther_description/urdf/gazebo.urdf.xacro
@@ -47,7 +47,7 @@
           <namespace>${namespace}</namespace>
           <remapping>imu_broadcaster/imu:=imu/data</remapping>
           <remapping>panther_base_controller/cmd_vel_unstamped:=cmd_vel</remapping>
-          <remapping>panther_base_controller/odom:=odom/wheels</remapping>
+          <remapping>panther_base_controller/odom:=odometry/wheels</remapping>
         </ros>
       </plugin>
     </gazebo>
@@ -82,9 +82,11 @@
         <topic>${ns}imu/data_raw</topic>
         <visualize>false</visualize>
         <enable_metrics>false</enable_metrics>
-        <frame_id>imu_link</frame_id>
         <ignition_frame_id>imu_link</ignition_frame_id>
         <imu>
+          <orientation_reference_frame parent_frame="${ns}base_link">
+            <localization>ENU</localization>
+          </orientation_reference_frame>
           <angular_velocity>
             <!-- rad/s -->
             <x>

--- a/panther_gazebo/config/gz_bridge.yaml
+++ b/panther_gazebo/config/gz_bridge.yaml
@@ -13,3 +13,9 @@
   subscriber_queue: 10
   publisher_queue: 10
   direction: GZ_TO_ROS
+
+- ros_topic_name: cmd_vel
+  gz_topic_name: cmd_vel
+  ros_type_name: geometry_msgs/msg/Twist
+  gz_type_name: ignition.msgs.Twist
+  direction: GZ_TO_ROS

--- a/panther_localization/README.md
+++ b/panther_localization/README.md
@@ -65,4 +65,4 @@ It converts raw GPS data into odometry data and publishes corrected GPS position
 #### navsat_transform - Publishers
 
 - `gps/filtered` [*sensor_msgs/msg/NavSatFix*]: GPS position after including sensor data from `ekf_local`.
-- `_odometry/gps` [*nav_msgs/msg/Odometry*]: transformed raw GPS data to odometry data.
+- `_odometry/gps` [*nav_msgs/msg/Odometry*]: transformed raw GPS data to odometry format.

--- a/panther_localization/README.md
+++ b/panther_localization/README.md
@@ -41,8 +41,10 @@ It converts raw GPS data into odometry data and publishes corrected GPS position
 
 #### ekf_global - Subscriber
 
-- `odometry/filtered/local` [*nav_msgs/msg/Odometry*]: robot odometry calculated from wheels.
+- `cmd_vel` [*geometry_msgs/msg/Twist*]: command velocity value.
+- `imu/data` [*sensor_msgs/msg/Imu*]: filtered IMU data.
 - `_odometry/gps` [*nav_msgs/msg/Odometry*]: transformed GPS data.
+- `odometry/wheels` [*nav_msgs/msg/Odometry*]: robot odometry calculated from wheels.
 - `/tf` [*tf2_msgs/msg/TFMessage*]: transforms of robot system.
 
 #### ekf_global - Publishers

--- a/panther_localization/README.md
+++ b/panther_localization/README.md
@@ -1,0 +1,66 @@
+# panther_localization
+
+The package is responsible for activating mods responsible for fusion of data related to the robot's location.
+
+## Launch files
+
+This package contains:
+
+- `ekf.launch.py` - is responsible for activating EKF filtration along with the necessary dependencies needed to operate GPS
+
+### ekf.launch.py - Launch Arguments
+
+- `ekf_config_path` [*string*, default: **panther_localization/config/ekf.yaml**]: path to the EKF config file.
+- `ekf_configuration` [*string*, default: **local**]: set the EKF mode: `local` combines wheel odometer and IMU data. `global` adds GPS data to this fusion.
+- `namespace` [*string*, default: **env(ROBOT_NAMESPACE)**]: add namespace to all launched nodes.
+- `use_sim` [*bool*, default: **False**]: whether simulation is used.
+
+### ekf.launch.py - Nodes Launched
+
+- `ekf_local` [*[robot_localization/ekf_node](https://github.com/cra-ros-pkg/robot_localization/tree/ros2)*]: Extended Kalman Filter node responsible for fusing odometry data related to starting position of the robot.
+- `ekf_global` [*[robot_localization/ekf_node](https://github.com/cra-ros-pkg/robot_localization/tree/ros2)*]: Extended Kalman Filter node responsible for data fusion from local fusion and global data (e.g. GPS). Runs when argument `ekf_configuration:=global`.
+- `navsat_transform` [*[robot_localization/navsat_transform_node](https://github.com/cra-ros-pkg/robot_localization/tree/ros2)*]:
+It converts raw GPS data into odometry data and publishes corrected GPS positions based on sensor data at a higher frequency.
+
+#### ekf_local - Subscriber
+
+- `cmd_vel` [*geometry_msgs/msg/Twist*]: command velocity value.
+- `odometry/wheels` [*nav_msgs/msg/Odometry*]: robot odometry calculated from wheels.
+- `imu/data` [*sensor_msgs/msg/Imu*]: filtered IMU data.
+- `/tf` [*tf2_msgs/msg/TFMessage*]: transforms of robot system.
+
+#### ekf_local - Publishers
+
+- `diagnostics` [*diagnostic_msgs/msg/DiagnosticArray*]: diagnostic data.
+- `odometry/filtered/local` [*nav_msgs/msg/Odometry*]: contains information about the position and velocities in relation to the initial position of the robot.
+- `/tf` [*tf2_msgs/msg/TFMessage*]: publishes `odom` to `base_link` transform.
+
+#### ekf_local - Service Servers
+
+- `~/set_pose` [*robot_localization/srv/SetPose*]: upon request, users can manually set the robot's position and speed. This is useful for resetting positions, e.g. during tests.
+
+#### ekf_global - Subscriber
+
+- `odometry/filtered/local` [*nav_msgs/msg/Odometry*]: robot odometry calculated from wheels.
+- `_odometry/gps` [*nav_msgs/msg/Odometry*]: transformed GPS data.
+- `/tf` [*tf2_msgs/msg/TFMessage*]: transforms of robot system.
+
+#### ekf_global - Publishers
+
+- `diagnostics` [*diagnostic_msgs/msg/DiagnosticArray*]: diagnostic data.
+- `odometry/filtered/global`[*nav_msgs/msg/Odometry*]: contains information about the position and velocities in relation to the initial position and orientation based on geographic  ENU convention (x-east, y-north, z-up). [*nav_msgs/Odometry*]: robot odometry calculated from wheels.
+- `/tf` [*tf2_msgs/msg/TFMessage*]: publishes `odom` to `base_link` transform.
+
+#### ekf_global - Service Servers
+
+- `~/set_pose` [*robot_localization/srv/SetPose*]:upon request, users can manually set the robot's position and speed. This is useful for resetting positions, e.g. during tests.
+
+#### navsat_transform - Subscriber
+
+- `gps/fix` [*sensor_msgs/msg/NavSatFix*]: raw GPS data.
+- `odometry/filtered/global` [*nav_msgs/msg/Odometry*]: odometry to transform to GPS position.
+
+#### navsat_transform - Publishers
+
+- `gps/filtered` [*sensor_msgs/msg/NavSatFix*]: GPS position after including sensor data from `ekf_local`.
+- `_odometry/gps` [*nav_msgs/msg/Odometry*]: transformed raw GPS data to odometry data.

--- a/panther_localization/config/ekf.yaml
+++ b/panther_localization/config/ekf.yaml
@@ -15,7 +15,7 @@
       publish_tf: true
       publish_acceleration: false
 
-      odom0: odom/wheels
+      odom0: odometry/wheels
       odom0_config: [false, false, false,
                     false, false, false,
                     true, true, false,
@@ -28,14 +28,14 @@
 
       imu0: imu/data
       imu0_config: [false, false, false,
-                    false, false, true,
+                    false, false, false,
                     false, false, false,
                     false, false, true,
                     false, false, false]
       imu0_queue_size: 5
       imu0_nodelay: true
       imu0_differential: false
-      imu0_relative: false
+      imu0_relative: true
       imu0_remove_gravitational_acceleration: false
 
       use_control: true
@@ -98,7 +98,7 @@
       base_link_frame: base_link
       world_frame: map
 
-      odom0: odometry/filtered/local
+      odom0: odometry/wheels
       odom0_config: [false, false, false,
                     false, false, false,
                     true, true, false,
@@ -107,9 +107,21 @@
       odom0_queue_size: 5
       odom0_nodelay: true
       odom0_differential: false
-      odom0_relative: false
+      odom0_relative: true
 
-      odom1: odometry/gps
+      imu0: imu/data
+      imu0_config: [false, false, false,
+                    false, false, true,
+                    false, false, false,
+                    false, false, true,
+                    false, false, false]
+      imu0_queue_size: 5
+      imu0_nodelay: true
+      imu0_differential: false
+      imu0_relative: false
+      imu0_remove_gravitational_acceleration: false
+
+      odom1: _odometry/gps
       odom1_config: [true,  true,  false,
                     false, false, false,
                     false, false, false,
@@ -137,12 +149,12 @@
 
   navsat_transform:
     ros__parameters:
-      frequency: 10.0
+      frequency: 5.0
       delay: 3.0
       magnetic_declination_radians: 0.0
       yaw_offset: 0.0
       zero_altitude: true
-      broadcast_cartesian_transform: true
+      broadcast_cartesian_transform: false
       publish_filtered_gps: true
       use_odometry_yaw: true
       wait_for_datum: false

--- a/panther_localization/config/ekf.yaml
+++ b/panther_localization/config/ekf.yaml
@@ -98,6 +98,7 @@
       base_link_frame: base_link
       world_frame: map
 
+      # Probably can use odometry/filtered/local here, however, due to the rotated imu_link tf, the orientation.yaw was determined incorrectly
       odom0: odometry/wheels
       odom0_config: [false, false, false,
                     false, false, false,
@@ -130,6 +131,11 @@
       odom1_queue_size: 10
       odom1_differential: false
       odom1_relative: false
+
+      use_control: true
+      control_timeout: 0.5
+      control_config: [true, true, false, false, false, true]
+      acceleration_limits: [2.7, 1.5, 0.0, 0.0, 0.0, 5.7] # Values taken from WH01_controller.yaml and WH02_controller.yaml inside panther_controller/config
 
       process_noise_covariance: [1.0,   0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
                                 0.0,    1.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,

--- a/panther_localization/config/ekf.yaml
+++ b/panther_localization/config/ekf.yaml
@@ -1,6 +1,5 @@
 /**:
-  ekf_node:
-    # Ref: http://docs.ros.org/en/noetic/api/robot_localization/html/state_estimation_nodes.html
+  ekf_local:
     ros__parameters:
       frequency: 50.0
       sensor_timeout: 0.05
@@ -29,14 +28,14 @@
 
       imu0: imu/data
       imu0_config: [false, false, false,
-                    false, false, false,
+                    false, false, true,
                     false, false, false,
                     false, false, true,
                     false, false, false]
       imu0_queue_size: 5
       imu0_nodelay: true
       imu0_differential: false
-      imu0_relative: true
+      imu0_relative: false
       imu0_remove_gravitational_acceleration: false
 
       use_control: true
@@ -85,3 +84,65 @@
                                     0.0,  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     1e-9,   0.0,    0.0,
                                     0.0,  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    1e-9,   0.0,
                                     0.0,  0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,     0.0,    0.0,    1e-9]
+
+  ekf_global:
+    ros__parameters:
+      frequency: 30.0
+      two_d_mode: true  # Recommended to use 2d mode for nav2 in mostly planar environments
+      print_diagnostics: true
+      debug: false
+      publish_tf: true
+
+      map_frame: map
+      odom_frame: odom
+      base_link_frame: base_link
+      world_frame: map
+
+      odom0: odometry/filtered/local
+      odom0_config: [false, false, false,
+                    false, false, false,
+                    true, true, false,
+                    false, false, true,
+                    false, false, false]
+      odom0_queue_size: 5
+      odom0_nodelay: true
+      odom0_differential: false
+      odom0_relative: false
+
+      odom1: odometry/gps
+      odom1_config: [true,  true,  false,
+                    false, false, false,
+                    false, false, false,
+                    false, false, false,
+                    false, false, false]
+      odom1_queue_size: 10
+      odom1_differential: false
+      odom1_relative: false
+
+      process_noise_covariance: [1.0,   0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    1.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    1e-3,   0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.3,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.3,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.01,   0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.5,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.5,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.1,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.3,    0.0,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.3,    0.0,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.3,    0.0,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.3,    0.0,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.3,    0.0,
+                                0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.0,     0.0,     0.0,    0.0,    0.0,    0.0,    0.0,    0.0,    0.3]
+
+  navsat_transform:
+    ros__parameters:
+      frequency: 10.0
+      delay: 3.0
+      magnetic_declination_radians: 0.0
+      yaw_offset: 0.0
+      zero_altitude: true
+      broadcast_cartesian_transform: true
+      publish_filtered_gps: true
+      use_odometry_yaw: true
+      wait_for_datum: false


### PR DESCRIPTION
### Description

Add EKF GPS configuration

### Modifications

- logic for process GPS data to odometry output
- `odom/wheels` -> `odometry/wheels` - more consistant (`odometry/filtered/global`, `odometry/filtered/local`, `odometry/wheels`)
- fix IMU ENU orientation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new component configuration `ANT02` for enhanced functionality.
  - Introduced `navsat_transform` section for better navigation satellite transformation.

- **Bug Fixes**
  - Corrected topic names for odometry in documentation and launch files.

- **Improvements**
  - Renamed `ekf_node` to `ekf_local` and adjusted related parameters.
  - Updated IMU and EKF configuration for improved localization.
  - Added new nodes `ekf_global` and `navsat_transform` in the launch files for better odometry and GPS data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->