### PR TITLE
Remove battery symlink

### DIFF
--- a/panther_battery/README.md
+++ b/panther_battery/README.md
@@ -51,9 +51,8 @@ Publishes battery state read from ADC unit for Panther version 1.2 and above, or
 
 [//]: # (ROS_API_NODE_PARAMETERS_START)
 
-- `~/adc/device0` [*string*, default: **/dev/adc0**]: ADC nr 0 IIO device. Used with Panther version 1.2 and above.
-- `~/adc/device1` [*string*, default: **/dev/adc1**]: ADC nr 1 IIO device. Used with Panther version 1.2 and above.
-- `~/adc/path` [*string*, default: **/sys/bus/iio/devices/**]: path of ADC devices mount.
+- `~/adc/device0` [*string*, default: **/sys/bus/iio/devices/iio:device0**]: ADC nr 0 IIO device. Used with Panther version 1.2 and above.
+- `~/adc/device1` [*string*, default: **/sys/bus/iio/devices/iio:device1**]: ADC nr 1 IIO device. Used with Panther version 1.2 and above.
 - `~/adc/ma_window_len/charge` [*int*, default: **10**]: window length of a moving average, used to smooth out battery charge readings. Used with Panther version 1.2 and above.
 - `~/adc/ma_window_len/temp` [*int*, default: **10**]: window length of a moving average, used to smooth out battery temperature readings. Used with Panther version 1.2 and above.
 - `~/battery_timeout` [*float*, default: **1.0**]: specifies the timeout in seconds. If the node fails to read battery data exceeding this duration, the node will publish an unknown battery state.

--- a/panther_battery/include/panther_battery/battery_node.hpp
+++ b/panther_battery/include/panther_battery/battery_node.hpp
@@ -43,7 +43,6 @@ private:
   void Initialize();
   void InitializeWithADCBattery();
   void InitializeWithRoboteqBattery();
-  std::string GetADCDevicePath(const std::string & adc_device_name) const;
 
   static constexpr int kADCCurrentOffset = 625;
 

--- a/panther_battery/src/battery_node.cpp
+++ b/panther_battery/src/battery_node.cpp
@@ -78,17 +78,13 @@ void BatteryNode::InitializeWithADCBattery()
 {
   RCLCPP_DEBUG(this->get_logger(), "Initializing with ADC data.");
 
-  this->declare_parameter<std::string>("adc/device0", "/dev/adc0");
-  this->declare_parameter<std::string>("adc/device1", "/dev/adc1");
-  this->declare_parameter<std::string>("adc/path", "/sys/bus/iio/devices");
+  this->declare_parameter<std::string>("adc/device0", "/sys/bus/iio/devices/iio:device0");
+  this->declare_parameter<std::string>("adc/device1", "/sys/bus/iio/devices/iio:device1");
   this->declare_parameter<int>("adc/ma_window_len/temp", 10);
   this->declare_parameter<int>("adc/ma_window_len/charge", 10);
 
-  const std::string adc0_device_name = this->get_parameter("adc/device0").as_string();
-  const std::string adc1_device_name = this->get_parameter("adc/device1").as_string();
-
-  const std::string adc0_device_path = GetADCDevicePath(adc0_device_name);
-  const std::string adc1_device_path = GetADCDevicePath(adc1_device_name);
+  const std::string adc0_device_path = this->get_parameter("adc/device0").as_string();
+  const std::string adc1_device_path = this->get_parameter("adc/device1").as_string();
 
   adc0_reader_ = std::make_shared<ADCDataReader>(adc0_device_path);
   adc1_reader_ = std::make_shared<ADCDataReader>(adc1_device_path);
@@ -162,20 +158,6 @@ void BatteryNode::BatteryPubTimerCB()
     return;
   }
   battery_publisher_->Publish();
-}
-
-std::string BatteryNode::GetADCDevicePath(const std::string & adc_device_name) const
-{
-  const std::string adc_path = this->get_parameter("adc/path").as_string();
-  std::filesystem::path adc_device;
-
-  if (std::filesystem::is_symlink(adc_device_name)) {
-    adc_device = std::filesystem::read_symlink(adc_device_name);
-  } else {
-    adc_device = std::filesystem::path(adc_device_name).filename();
-  }
-
-  return (adc_path / adc_device).string();
 }
 
 }  // namespace panther_battery

--- a/panther_battery/test/include/test_battery_node.hpp
+++ b/panther_battery/test/include/test_battery_node.hpp
@@ -47,8 +47,8 @@ protected:
   template <typename T>
   void WriteNumberToFile(const T number, const std::string & file_path);
 
-  static constexpr char kADCDevice0[] = "adc0";
-  static constexpr char kADCDevice1[] = "adc1";
+  static constexpr char kADCDevice0[] = "iio:device0";
+  static constexpr char kADCDevice1[] = "iio:device1";
 
   std::filesystem::path device0_path_;
   std::filesystem::path device1_path_;
@@ -72,8 +72,8 @@ TestBatteryNode::TestBatteryNode(const float panther_version, const bool dual_ba
     device0_path_ = std::filesystem::path(testing::TempDir()) / kADCDevice0;
     device1_path_ = std::filesystem::path(testing::TempDir()) / kADCDevice1;
 
-    params.push_back(rclcpp::Parameter("adc/device0", kADCDevice0));
-    params.push_back(rclcpp::Parameter("adc/device1", kADCDevice1));
+    params.push_back(rclcpp::Parameter("adc/device0", device0_path_.string()));
+    params.push_back(rclcpp::Parameter("adc/device1", device1_path_.string()));
     params.push_back(rclcpp::Parameter("adc/path", testing::TempDir()));
 
     // Create the device0 and device1 directories if they do not exist


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated default paths for ADC devices in the README for Panther version 1.2 and above.

- **Refactor**
  - Modified ADC device paths to align with correct system locations.
  - Removed `GetADCDevicePath` method and integrated its functionality directly into the code.

- **Tests**
  - Updated test parameters to use full path strings for ADC devices instead of device names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->