### PR TITLE
Hotfix handle can timeout

### DIFF
--- a/panther/panther_hardware.repos
+++ b/panther/panther_hardware.repos
@@ -10,8 +10,7 @@ repositories:
   panther_msgs:
     type: git
     url: https://github.com/husarion/panther_msgs.git
-    # version: 12b77cf8f5a8ececfc737ab2806d04df0d7ed60d
-    version: hotfix-handle-can-timeout # TODO: update before merging!
+    version: fcee4d9f249a62adc113eb80be4885b08024ee9c
   ros_components_description:
     type: git
     url: https://github.com/husarion/ros_components_description.git

--- a/panther/panther_hardware.repos
+++ b/panther/panther_hardware.repos
@@ -10,7 +10,8 @@ repositories:
   panther_msgs:
     type: git
     url: https://github.com/husarion/panther_msgs.git
-    version: 12b77cf8f5a8ececfc737ab2806d04df0d7ed60d
+    # version: 12b77cf8f5a8ececfc737ab2806d04df0d7ed60d
+    version: hotfix-handle-can-timeout # TODO: update before merging!
   ros_components_description:
     type: git
     url: https://github.com/husarion/ros_components_description.git

--- a/panther/panther_simulation.repos
+++ b/panther/panther_simulation.repos
@@ -10,7 +10,7 @@ repositories:
   panther_msgs:
     type: git
     url: https://github.com/husarion/panther_msgs.git
-    version: 12b77cf8f5a8ececfc737ab2806d04df0d7ed60d
+    version: fcee4d9f249a62adc113eb80be4885b08024ee9c
   ros_components_description:
     type: git
     url: https://github.com/husarion/ros_components_description.git

--- a/panther_battery/src/roboteq_battery.cpp
+++ b/panther_battery/src/roboteq_battery.cpp
@@ -74,7 +74,7 @@ void RoboteqBattery::ValidateDriverStateMsg(const rclcpp::Time & header_stamp)
     throw std::runtime_error("Driver state message timeout.");
   }
 
-  if (driver_state_->front.can_net_err || driver_state_->rear.can_net_err) {
+  if (driver_state_->front.can_error || driver_state_->rear.can_error) {
     throw std::runtime_error("Motor controller CAN network error.");
   }
 }

--- a/panther_battery/src/roboteq_battery.cpp
+++ b/panther_battery/src/roboteq_battery.cpp
@@ -74,8 +74,8 @@ void RoboteqBattery::ValidateDriverStateMsg(const rclcpp::Time & header_stamp)
     throw std::runtime_error("Driver state message timeout.");
   }
 
-  if (driver_state_->front.can_error || driver_state_->rear.can_error) {
-    throw std::runtime_error("Motor controller CAN network error.");
+  if (driver_state_->front.heartbeat_timeout || driver_state_->rear.heartbeat_timeout) {
+    throw std::runtime_error("Motor controller heartbeat timeout error.");
   }
 }
 

--- a/panther_battery/test/test_roboteq_battery.cpp
+++ b/panther_battery/test/test_roboteq_battery.cpp
@@ -243,10 +243,10 @@ TEST_F(TestRoboteqBattery, ValidateDriverStateMsg)
   EXPECT_NO_THROW(battery_->ValidateDriverStateMsg(stamp));
 
   // Check can net error throw
-  driver_state_->front.can_net_err = true;
+  driver_state_->front.can_error = true;
   EXPECT_THROW(battery_->ValidateDriverStateMsg(stamp), std::runtime_error);
-  driver_state_->front.can_net_err = false;
-  driver_state_->rear.can_net_err = true;
+  driver_state_->front.can_error = false;
+  driver_state_->rear.can_error = true;
   EXPECT_THROW(battery_->ValidateDriverStateMsg(stamp), std::runtime_error);
 }
 

--- a/panther_battery/test/test_roboteq_battery.cpp
+++ b/panther_battery/test/test_roboteq_battery.cpp
@@ -242,11 +242,11 @@ TEST_F(TestRoboteqBattery, ValidateDriverStateMsg)
   stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
   EXPECT_NO_THROW(battery_->ValidateDriverStateMsg(stamp));
 
-  // Check can net error throw
-  driver_state_->front.can_error = true;
+  // Check heartbeat timeout error throw
+  driver_state_->front.heartbeat_timeout = true;
   EXPECT_THROW(battery_->ValidateDriverStateMsg(stamp), std::runtime_error);
-  driver_state_->front.can_error = false;
-  driver_state_->rear.can_error = true;
+  driver_state_->front.heartbeat_timeout = false;
+  driver_state_->rear.heartbeat_timeout = true;
   EXPECT_THROW(battery_->ValidateDriverStateMsg(stamp), std::runtime_error);
 }
 

--- a/panther_hardware_interfaces/config/canopen_configuration.yaml
+++ b/panther_hardware_interfaces/config/canopen_configuration.yaml
@@ -1,3 +1,6 @@
+options:
+  heartbeat_multiplier: 3.0
+
 master:
   node_id: 3
   sync_period: 1000000 # us

--- a/panther_hardware_interfaces/config/master.dcf
+++ b/panther_hardware_interfaces/config/master.dcf
@@ -224,7 +224,9 @@ AccessType=rw
 CompactSubObj=127
 
 [1016Value]
-NrOfEntries=0
+NrOfEntries=2
+1=0x0001012C
+2=0x0002012C
 
 [1017]
 ParameterName=Producer heartbeat time

--- a/panther_hardware_interfaces/config/roboteq_motor_controllers_v80_21a.eds
+++ b/panther_hardware_interfaces/config/roboteq_motor_controllers_v80_21a.eds
@@ -588,7 +588,7 @@ DataType=0x0006
 LowLimit=
 HighLimit=
 AccessType=rw
-DefaultValue=0
+DefaultValue=100
 PDOMapping=0
 ObjFlags=0x0
 

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/motors_controller.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/motors_controller.hpp
@@ -47,7 +47,7 @@ public:
   void Initialize();
 
   /**
-   * @brief Deinitializes can communication
+   * @brief Deinitialize can communication
    */
   void Deinitialize();
 
@@ -60,11 +60,18 @@ public:
   void Activate();
 
   /**
-   * @brief Updates current motors' states (position, velocity, current).
+   * @brief Updates current communication state with Roboteq drivers
    *
    * @exception std::runtime_error if CAN error was detected
    */
-  void UpdateMotorsStates();
+  void UpdateCommunicationState();
+
+  /**
+   * @brief Updates current motors' state (position, velocity, current).
+   *
+   * @exception std::runtime_error if CAN error was detected
+   */
+  void UpdateMotorsState();
 
   /**
    * @brief Updates current Roboteq driver state (flags, temperatures, voltage, battery current)

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system.hpp
@@ -83,11 +83,12 @@ protected:
   void ConfigureMotorsController();
   void ConfigureEStop();
 
-  void UpdateMotorsStates();
+  void UpdateMotorsState();
   void UpdateDriverState();
+  void UpdateEStopState();
 
   void UpdateHwStates();
-  void UpdateMotorsStatesDataTimedOut();
+  void UpdateMotorsStateDataTimedOut();
   bool AreVelocityCommandsNearZero();
   bool IsPantherVersionAtLeast(const float version);
 

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system_ros_interface.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system_ros_interface.hpp
@@ -63,6 +63,9 @@ struct CANErrors
 
   bool front_can_net_err;
   bool rear_can_net_err;
+
+  bool front_heartbeat_timeout;
+  bool rear_heartbeat_timeout;
 };
 
 /**

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system_ros_interface.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/panther_system_ros_interface.hpp
@@ -61,8 +61,8 @@ struct CANErrors
   bool front_driver_state_data_timed_out;
   bool rear_driver_state_data_timed_out;
 
-  bool front_can_net_err;
-  bool rear_can_net_err;
+  bool front_can_error;
+  bool rear_can_error;
 
   bool front_heartbeat_timeout;
   bool rear_heartbeat_timeout;

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/roboteq_data_converters.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/roboteq_data_converters.hpp
@@ -193,7 +193,7 @@ public:
     const RoboteqMotorState & left_state, const RoboteqMotorState & right_state,
     const bool data_timed_out);
   void SetDriverState(const RoboteqDriverState & state, const bool data_timed_out);
-  void SetCANNetErr(const bool can_net_err) { can_net_err_ = can_net_err; }
+  void SetCANError(const bool can_error) { can_error_ = can_error; }
   void SetHeartbeatTimeout(const bool heartbeat_timeout) { heartbeat_timeout_ = heartbeat_timeout; }
 
   bool IsFlagError() const
@@ -205,7 +205,7 @@ public:
   bool IsError() const
   {
     return IsFlagError() || motor_states_data_timed_out_ || driver_state_data_timed_out_ ||
-           can_net_err_ || heartbeat_timeout_;
+           can_error_ || heartbeat_timeout_;
   }
 
   const MotorState & GetLeftMotorState() const { return left_motor_state_; }
@@ -214,7 +214,7 @@ public:
 
   bool IsMotorStatesDataTimedOut() const { return motor_states_data_timed_out_; }
   bool IsDriverStateDataTimedOut() const { return driver_state_data_timed_out_; }
-  bool IsCANNetErr() const { return can_net_err_; }
+  bool IsCANError() const { return can_error_; }
   bool IsHeartbeatTimeout() const { return heartbeat_timeout_; }
 
   const FaultFlag & GetFaultFlag() const { return fault_flags_; }
@@ -240,7 +240,7 @@ private:
 
   bool motor_states_data_timed_out_ = false;
   bool driver_state_data_timed_out_ = false;
-  bool can_net_err_ = false;
+  bool can_error_ = false;
   bool heartbeat_timeout_ = false;
 };
 

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/roboteq_data_converters.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/roboteq_data_converters.hpp
@@ -194,6 +194,7 @@ public:
     const bool data_timed_out);
   void SetDriverState(const RoboteqDriverState & state, const bool data_timed_out);
   void SetCANNetErr(const bool can_net_err) { can_net_err_ = can_net_err; }
+  void SetHeartbeatTimeout(const bool heartbeat_timeout) { heartbeat_timeout_ = heartbeat_timeout; }
 
   bool IsFlagError() const
   {
@@ -204,7 +205,7 @@ public:
   bool IsError() const
   {
     return IsFlagError() || motor_states_data_timed_out_ || driver_state_data_timed_out_ ||
-           can_net_err_;
+           can_net_err_ || heartbeat_timeout_;
   }
 
   const MotorState & GetLeftMotorState() const { return left_motor_state_; }
@@ -214,6 +215,7 @@ public:
   bool IsMotorStatesDataTimedOut() const { return motor_states_data_timed_out_; }
   bool IsDriverStateDataTimedOut() const { return driver_state_data_timed_out_; }
   bool IsCANNetErr() const { return can_net_err_; }
+  bool IsHeartbeatTimeout() const { return heartbeat_timeout_; }
 
   const FaultFlag & GetFaultFlag() const { return fault_flags_; }
   const ScriptFlag & GetScriptFlag() const { return script_flags_; }
@@ -239,6 +241,7 @@ private:
   bool motor_states_data_timed_out_ = false;
   bool driver_state_data_timed_out_ = false;
   bool can_net_err_ = false;
+  bool heartbeat_timeout_ = false;
 };
 
 }  // namespace panther_hardware_interfaces

--- a/panther_hardware_interfaces/include/panther_hardware_interfaces/roboteq_driver.hpp
+++ b/panther_hardware_interfaces/include/panther_hardware_interfaces/roboteq_driver.hpp
@@ -80,7 +80,15 @@ public:
    */
   std::future<void> Boot();
 
+  /**
+   * @brief Returns true if CAN error was detected.
+   */
   bool IsCANError() const { return can_error_.load(); }
+
+  /**
+   * @brief Returns true if heartbeat timeout encountered.
+   */
+  bool IsHeartbeatTimeout() const { return heartbeat_timeout_.load(); }
 
   /**
    * @brief Reads motors' state data returned from Roboteq (PDO 1 and 2) and saves
@@ -150,9 +158,13 @@ private:
     can_error_.store(true);
   }
 
+  void OnHeartbeat(const bool occurred) noexcept override { heartbeat_timeout_.store(occurred); }
+
+  std::mutex boot_mtx_;
   std::promise<void> boot_promise_;
 
   std::atomic_bool can_error_;
+  std::atomic_bool heartbeat_timeout_;
 
   std::mutex position_timestamp_mtx_;
   timespec last_position_timestamp_;

--- a/panther_hardware_interfaces/src/motors_controller.cpp
+++ b/panther_hardware_interfaces/src/motors_controller.cpp
@@ -98,8 +98,8 @@ void MotorsController::Activate()
 
 void MotorsController::UpdateCommunicationState()
 {
-  front_data_.SetCANNetErr(canopen_controller_.GetFrontDriver()->IsCANError());
-  rear_data_.SetCANNetErr(canopen_controller_.GetRearDriver()->IsCANError());
+  front_data_.SetCANError(canopen_controller_.GetFrontDriver()->IsCANError());
+  rear_data_.SetCANError(canopen_controller_.GetRearDriver()->IsCANError());
 
   front_data_.SetHeartbeatTimeout(canopen_controller_.GetFrontDriver()->IsHeartbeatTimeout());
   rear_data_.SetHeartbeatTimeout(canopen_controller_.GetRearDriver()->IsHeartbeatTimeout());
@@ -117,7 +117,7 @@ void MotorsController::UpdateMotorsState()
 
   UpdateCommunicationState();
 
-  if (front_data_.IsCANNetErr() || rear_data_.IsCANNetErr()) {
+  if (front_data_.IsCANError() || rear_data_.IsCANError()) {
     throw std::runtime_error("CAN error.");
   }
 
@@ -138,7 +138,7 @@ void MotorsController::UpdateDriversState()
 
   UpdateCommunicationState();
 
-  if (front_data_.IsCANNetErr() || rear_data_.IsCANNetErr()) {
+  if (front_data_.IsCANError() || rear_data_.IsCANError()) {
     throw std::runtime_error("CAN error.");
   }
 

--- a/panther_hardware_interfaces/src/motors_controller.cpp
+++ b/panther_hardware_interfaces/src/motors_controller.cpp
@@ -96,7 +96,16 @@ void MotorsController::Activate()
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }
 
-void MotorsController::UpdateMotorsStates()
+void MotorsController::UpdateCommunicationState()
+{
+  front_data_.SetCANNetErr(canopen_controller_.GetFrontDriver()->IsCANError());
+  rear_data_.SetCANNetErr(canopen_controller_.GetRearDriver()->IsCANError());
+
+  front_data_.SetHeartbeatTimeout(canopen_controller_.GetFrontDriver()->IsHeartbeatTimeout());
+  rear_data_.SetHeartbeatTimeout(canopen_controller_.GetRearDriver()->IsHeartbeatTimeout());
+}
+
+void MotorsController::UpdateMotorsState()
 {
   timespec current_time;
   clock_gettime(CLOCK_MONOTONIC, &current_time);
@@ -106,11 +115,14 @@ void MotorsController::UpdateMotorsStates()
   SetMotorsStates(
     rear_data_, canopen_controller_.GetRearDriver()->ReadRoboteqMotorsStates(), current_time);
 
-  front_data_.SetCANNetErr(canopen_controller_.GetFrontDriver()->IsCANError());
-  rear_data_.SetCANNetErr(canopen_controller_.GetRearDriver()->IsCANError());
+  UpdateCommunicationState();
 
   if (front_data_.IsCANNetErr() || rear_data_.IsCANNetErr()) {
-    throw std::runtime_error("CAN error detected when trying to read motors states.");
+    throw std::runtime_error("CAN error.");
+  }
+
+  if (front_data_.IsHeartbeatTimeout() || rear_data_.IsHeartbeatTimeout()) {
+    throw std::runtime_error("Motor controller heartbeat timeout.");
   }
 }
 
@@ -124,11 +136,14 @@ void MotorsController::UpdateDriversState()
   SetDriverState(
     rear_data_, canopen_controller_.GetRearDriver()->ReadRoboteqDriverState(), current_time);
 
-  front_data_.SetCANNetErr(canopen_controller_.GetFrontDriver()->IsCANError());
-  rear_data_.SetCANNetErr(canopen_controller_.GetRearDriver()->IsCANError());
+  UpdateCommunicationState();
 
   if (front_data_.IsCANNetErr() || rear_data_.IsCANNetErr()) {
-    throw std::runtime_error("CAN error detected when trying to read drivers states.");
+    throw std::runtime_error("CAN error.");
+  }
+
+  if (front_data_.IsHeartbeatTimeout() || rear_data_.IsHeartbeatTimeout()) {
+    throw std::runtime_error("Motor controller heartbeat timeout.");
   }
 }
 

--- a/panther_hardware_interfaces/src/panther_system.cpp
+++ b/panther_hardware_interfaces/src/panther_system.cpp
@@ -587,8 +587,8 @@ void PantherSystem::UpdateDriverStateMsg()
   can_errors.rear_driver_state_data_timed_out =
     motors_controller_->GetRearData().IsDriverStateDataTimedOut();
 
-  can_errors.front_can_net_err = motors_controller_->GetFrontData().IsCANNetErr();
-  can_errors.rear_can_net_err = motors_controller_->GetRearData().IsCANNetErr();
+  can_errors.front_can_error = motors_controller_->GetFrontData().IsCANError();
+  can_errors.rear_can_error = motors_controller_->GetRearData().IsCANError();
 
   can_errors.front_heartbeat_timeout = motors_controller_->GetFrontData().IsHeartbeatTimeout();
   can_errors.rear_heartbeat_timeout = motors_controller_->GetRearData().IsHeartbeatTimeout();

--- a/panther_hardware_interfaces/src/panther_system.cpp
+++ b/panther_hardware_interfaces/src/panther_system.cpp
@@ -246,16 +246,16 @@ std::vector<CommandInterface> PantherSystem::export_command_interfaces()
 
 return_type PantherSystem::read(const rclcpp::Time & time, const rclcpp::Duration & /* period */)
 {
-  UpdateMotorsStates();
-
-  const bool e_stop = e_stop_->ReadEStopState();
-  panther_system_ros_interface_->PublishEStopStateIfChanged(e_stop);
+  UpdateMotorsState();
 
   if (time >= next_driver_state_update_time_) {
     UpdateDriverState();
+    UpdateDriverStateMsg();
     panther_system_ros_interface_->PublishDriverState();
     next_driver_state_update_time_ = time + driver_states_update_period_;
   }
+
+  UpdateEStopState();
 
   return return_type::OK;
 }
@@ -476,16 +476,17 @@ void PantherSystem::ConfigureEStop()
   RCLCPP_INFO(logger_, "Successfully configured E-Stop");
 }
 
-void PantherSystem::UpdateMotorsStates()
+void PantherSystem::UpdateMotorsState()
 {
   try {
-    motors_controller_->UpdateMotorsStates();
+    motors_controller_->UpdateMotorsState();
     UpdateHwStates();
-    UpdateMotorsStatesDataTimedOut();
+    UpdateMotorsStateDataTimedOut();
   } catch (const std::runtime_error & e) {
     roboteq_error_filter_->UpdateError(ErrorsFilterIds::READ_PDO_MOTOR_STATES, true);
-    RCLCPP_WARN_STREAM_THROTTLE(
-      logger_, steady_clock_, 1000,
+
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      logger_, steady_clock_, 10000,
       "An exception occurred while updating motors states: " << e.what());
   }
 }
@@ -494,14 +495,27 @@ void PantherSystem::UpdateDriverState()
 {
   try {
     motors_controller_->UpdateDriversState();
-    UpdateDriverStateMsg();
     UpdateFlagErrors();
     UpdateDriverStateDataTimedOut();
   } catch (const std::runtime_error & e) {
-    RCLCPP_WARN_STREAM(
-      logger_, "An exception occurred while updating drivers states: " << e.what());
     roboteq_error_filter_->UpdateError(ErrorsFilterIds::READ_PDO_DRIVER_STATE, true);
+
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      logger_, steady_clock_, 10000,
+      "An exception occurred while updating drivers states: " << e.what());
   }
+}
+
+void PantherSystem::UpdateEStopState()
+{
+  if (
+    motors_controller_->GetFrontData().IsHeartbeatTimeout() ||
+    motors_controller_->GetRearData().IsHeartbeatTimeout()) {
+    e_stop_->TriggerEStop();
+  }
+
+  const bool e_stop = e_stop_->ReadEStopState();
+  panther_system_ros_interface_->PublishEStopStateIfChanged(e_stop);
 }
 
 void PantherSystem::UpdateHwStates()
@@ -530,7 +544,7 @@ void PantherSystem::UpdateHwStates()
   hw_states_efforts_[3] = rr.GetTorque();
 }
 
-void PantherSystem::UpdateMotorsStatesDataTimedOut()
+void PantherSystem::UpdateMotorsStateDataTimedOut()
 {
   if (
     motors_controller_->GetFrontData().IsMotorStatesDataTimedOut() ||
@@ -575,6 +589,9 @@ void PantherSystem::UpdateDriverStateMsg()
 
   can_errors.front_can_net_err = motors_controller_->GetFrontData().IsCANNetErr();
   can_errors.rear_can_net_err = motors_controller_->GetRearData().IsCANNetErr();
+
+  can_errors.front_heartbeat_timeout = motors_controller_->GetFrontData().IsHeartbeatTimeout();
+  can_errors.rear_heartbeat_timeout = motors_controller_->GetRearData().IsHeartbeatTimeout();
 
   panther_system_ros_interface_->UpdateMsgErrors(can_errors);
 }

--- a/panther_hardware_interfaces/src/panther_system.cpp
+++ b/panther_hardware_interfaces/src/panther_system.cpp
@@ -486,7 +486,7 @@ void PantherSystem::UpdateMotorsState()
     roboteq_error_filter_->UpdateError(ErrorsFilterIds::READ_PDO_MOTOR_STATES, true);
 
     RCLCPP_ERROR_STREAM_THROTTLE(
-      logger_, steady_clock_, 10000,
+      logger_, steady_clock_, 5000,
       "An exception occurred while updating motors states: " << e.what());
   }
 }
@@ -501,7 +501,7 @@ void PantherSystem::UpdateDriverState()
     roboteq_error_filter_->UpdateError(ErrorsFilterIds::READ_PDO_DRIVER_STATE, true);
 
     RCLCPP_ERROR_STREAM_THROTTLE(
-      logger_, steady_clock_, 10000,
+      logger_, steady_clock_, 5000,
       "An exception occurred while updating drivers states: " << e.what());
   }
 }

--- a/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
+++ b/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
@@ -176,6 +176,9 @@ void PantherSystemRosInterface::UpdateMsgErrors(const CANErrors & can_errors)
 
   driver_state.front.can_net_err = can_errors.front_can_net_err;
   driver_state.rear.can_net_err = can_errors.rear_can_net_err;
+
+  driver_state.front.heartbeat_timeout_error = can_errors.front_heartbeat_timeout;
+  driver_state.rear.heartbeat_timeout_error = can_errors.rear_heartbeat_timeout;
 }
 
 void PantherSystemRosInterface::PublishEStopStateMsg(const bool e_stop)

--- a/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
+++ b/panther_hardware_interfaces/src/panther_system_ros_interface.cpp
@@ -174,11 +174,11 @@ void PantherSystemRosInterface::UpdateMsgErrors(const CANErrors & can_errors)
   driver_state.front.driver_state_data_timed_out = can_errors.front_driver_state_data_timed_out;
   driver_state.rear.driver_state_data_timed_out = can_errors.rear_driver_state_data_timed_out;
 
-  driver_state.front.can_net_err = can_errors.front_can_net_err;
-  driver_state.rear.can_net_err = can_errors.rear_can_net_err;
+  driver_state.front.can_error = can_errors.front_can_error;
+  driver_state.rear.can_error = can_errors.rear_can_error;
 
-  driver_state.front.heartbeat_timeout_error = can_errors.front_heartbeat_timeout;
-  driver_state.rear.heartbeat_timeout_error = can_errors.rear_heartbeat_timeout;
+  driver_state.front.heartbeat_timeout = can_errors.front_heartbeat_timeout;
+  driver_state.rear.heartbeat_timeout = can_errors.rear_heartbeat_timeout;
 }
 
 void PantherSystemRosInterface::PublishEStopStateMsg(const bool e_stop)

--- a/panther_hardware_interfaces/src/roboteq_data_converters.cpp
+++ b/panther_hardware_interfaces/src/roboteq_data_converters.cpp
@@ -264,6 +264,7 @@ std::map<std::string, bool> RoboteqData::GetErrorMap() const
   error_map.emplace("motor_states_data_timed_out", IsMotorStatesDataTimedOut());
   error_map.emplace("driver_state_data_timed_out", IsDriverStateDataTimedOut());
   error_map.emplace("can_net_err", IsCANNetErr());
+  error_map.emplace("heartbeat_timeout_error", IsHeartbeatTimeout());
 
   return error_map;
 }

--- a/panther_hardware_interfaces/src/roboteq_data_converters.cpp
+++ b/panther_hardware_interfaces/src/roboteq_data_converters.cpp
@@ -263,8 +263,8 @@ std::map<std::string, bool> RoboteqData::GetErrorMap() const
 
   error_map.emplace("motor_states_data_timed_out", IsMotorStatesDataTimedOut());
   error_map.emplace("driver_state_data_timed_out", IsDriverStateDataTimedOut());
-  error_map.emplace("can_net_err", IsCANNetErr());
-  error_map.emplace("heartbeat_timeout_error", IsHeartbeatTimeout());
+  error_map.emplace("can_error", IsCANError());
+  error_map.emplace("heartbeat_timeout", IsHeartbeatTimeout());
 
   return error_map;
 }

--- a/panther_hardware_interfaces/test/test_motors_controller.cpp
+++ b/panther_hardware_interfaces/test/test_motors_controller.cpp
@@ -132,7 +132,7 @@ public:
   ~TestMotorsController() { motors_controller_->Deinitialize(); }
 };
 
-TEST_F(TestMotorsController, UpdateMotorsStates)
+TEST_F(TestMotorsController, UpdateMotorsState)
 {
   using panther_hardware_interfaces_test::DriverChannel;
 
@@ -170,7 +170,7 @@ TEST_F(TestMotorsController, UpdateMotorsStates)
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-  motors_controller_->UpdateMotorsStates();
+  motors_controller_->UpdateMotorsState();
 
   const auto & fl = motors_controller_->GetFrontData().GetLeftMotorState();
   const auto & fr = motors_controller_->GetFrontData().GetRightMotorState();
@@ -194,21 +194,21 @@ TEST_F(TestMotorsController, UpdateMotorsStates)
   EXPECT_FLOAT_EQ(rr.GetTorque(), rr_current * kRbtqCurrentFbToNewtonMeters);
 }
 
-TEST_F(TestMotorsController, UpdateMotorsStatesTimestamps)
+TEST_F(TestMotorsController, UpdateMotorsStateTimestamps)
 {
-  motors_controller_->UpdateMotorsStates();
+  motors_controller_->UpdateMotorsState();
 
   std::this_thread::sleep_for(
     panther_hardware_interfaces_test::kCANopenSettings.pdo_motor_states_timeout_ms +
     std::chrono::milliseconds(10));
 
-  motors_controller_->UpdateMotorsStates();
+  motors_controller_->UpdateMotorsState();
 
   EXPECT_FALSE(motors_controller_->GetFrontData().IsMotorStatesDataTimedOut());
   EXPECT_FALSE(motors_controller_->GetRearData().IsMotorStatesDataTimedOut());
 }
 
-TEST(TestMotorsControllerOthers, UpdateMotorsStatesTimeout)
+TEST(TestMotorsControllerOthers, UpdateMotorsStateTimeout)
 {
   std::shared_ptr<panther_hardware_interfaces_test::RoboteqsMock> roboteqs_mock_;
   std::unique_ptr<panther_hardware_interfaces::MotorsController> motors_controller_;
@@ -224,13 +224,13 @@ TEST(TestMotorsControllerOthers, UpdateMotorsStatesTimeout)
   motors_controller_->Initialize();
   motors_controller_->Activate();
 
-  motors_controller_->UpdateMotorsStates();
+  motors_controller_->UpdateMotorsState();
 
   std::this_thread::sleep_for(
     panther_hardware_interfaces_test::kCANopenSettings.pdo_motor_states_timeout_ms +
     std::chrono::milliseconds(10));
 
-  motors_controller_->UpdateMotorsStates();
+  motors_controller_->UpdateMotorsState();
 
   EXPECT_TRUE(motors_controller_->GetFrontData().IsMotorStatesDataTimedOut());
   EXPECT_TRUE(motors_controller_->GetRearData().IsMotorStatesDataTimedOut());

--- a/panther_hardware_interfaces/test/test_panther_system_ros_interface.cpp
+++ b/panther_hardware_interfaces/test/test_panther_system_ros_interface.cpp
@@ -238,8 +238,8 @@ TEST_F(TestPantherSystemRosInterface, Errors)
   can_errors.front_driver_state_data_timed_out = false;
   can_errors.rear_driver_state_data_timed_out = true;
 
-  can_errors.front_can_net_err = false;
-  can_errors.rear_can_net_err = true;
+  can_errors.front_can_error = false;
+  can_errors.rear_can_error = true;
 
   panther_system_ros_interface_->UpdateMsgErrors(can_errors);
 
@@ -260,8 +260,8 @@ TEST_F(TestPantherSystemRosInterface, Errors)
   EXPECT_FALSE(driver_state_msg_->front.driver_state_data_timed_out);
   EXPECT_TRUE(driver_state_msg_->rear.driver_state_data_timed_out);
 
-  EXPECT_FALSE(driver_state_msg_->front.can_net_err);
-  EXPECT_TRUE(driver_state_msg_->rear.can_net_err);
+  EXPECT_FALSE(driver_state_msg_->front.can_error);
+  EXPECT_TRUE(driver_state_msg_->rear.can_error);
 }
 
 int main(int argc, char ** argv)

--- a/panther_hardware_interfaces/test/test_roboteq_data_converters.cpp
+++ b/panther_hardware_interfaces/test/test_roboteq_data_converters.cpp
@@ -249,12 +249,12 @@ TEST(TestRoboteqDataConverters, RoboteqData)
 
   ASSERT_FALSE(roboteq_data.IsError());
 
-  roboteq_data.SetCANNetErr(true);
+  roboteq_data.SetCANError(true);
 
   ASSERT_TRUE(roboteq_data.IsError());
-  ASSERT_TRUE(roboteq_data.IsCANNetErr());
+  ASSERT_TRUE(roboteq_data.IsCANError());
 
-  roboteq_data.SetCANNetErr(false);
+  roboteq_data.SetCANError(false);
   ASSERT_FALSE(roboteq_data.IsError());
 
   const float pos_to_radians = 0.00013055156;


### PR DESCRIPTION
### Description

Changes incorporate monitoring CAN communication heartbeat.

### Modifications

- Add handling new error -> heartbeat timeout
- Rename `can_net_error` to `can_error`, as it is originally in the CANopen library
- Add missing error handling for setting `std::promise` once
- Add updating e_stop policy once the communication via CAN is corrupted

### Tests

- [x] Host
- [x] Docker
- [x] Recovery
- [x] Interaction with WebUI (e_stop resetting)

### First merge this PR ❗ 
https://github.com/husarion/panther_msgs/pull/76