### PR TITLE
Fix absolute links

### DIFF
--- a/panther_bringup/README.md
+++ b/panther_bringup/README.md
@@ -12,8 +12,8 @@ The package contains the default configuration and launch files necessary to sta
 
 ## Default Nodes Launched
 
-- `battery_driver` [*[panther_battery/battery_node](https://github.com/husarion/panther_ros/panther_battery/src/main.cpp)*]: node responsible for monitoring and publishing the internal Battery state of the Husarion Panther robot. For more information, refer to [panther_battery](https://github.com/husarion/panther_ros/panther_battery/README.md).
-- `ekf_filter` [*[robot_localization/ekf_node](https://github.com/cra-ros-pkg/robot_localization/blob/humble-devel/src/ekf_node.cpp)*]: Extended Kalman Filter node for more accurate odometry. For more information, refer to [robot_localization](https://github.com/cra-ros-pkg/robot_localization/tree/noetic-devel). The default configuration is stored in [ekf_config.yaml](https://github.com/husarion/panther_ros/panther_gazebo/config/ekf_config.yaml).
+- `battery_driver` [*[panther_battery/battery_node](../panther_battery/src/main.cpp)*]: node responsible for monitoring and publishing the internal Battery state of the Husarion Panther robot. For more information, refer to [panther_battery](../panther_battery/README.md).
+- `ekf_filter` [*[robot_localization/ekf_node](https://github.com/cra-ros-pkg/robot_localization/blob/humble-devel/src/ekf_node.cpp)*]: Extended Kalman Filter node for more accurate odometry. For more information, refer to [robot_localization](https://github.com/cra-ros-pkg/robot_localization/tree/noetic-devel). The default configuration is stored in [ekf_config.yaml](../panther_gazebo/config/ekf_config.yaml).
 - `imu_container` [*[phidgets_spatial/phidgets::SpatialRosI](https://github.com/ros-drivers/phidgets_drivers/blob/humble/phidgets_spatial/src/spatial_ros_i.cpp)*, *[imu_filter_madgwick/ImuFilterMadgwickRos](https://github.com/CCNYRoboticsLab/imu_tools/blob/humble/imu_filter_madgwick/src/imu_filter_node.cpp)*]: container responsible for running Phidget Spatial IMU ROS driver, filtering and fusing the IMU data. It composes the `phidgets_spatial_node` and `imu_filter_node`.
 
 ## Bringup Launch Arguments

--- a/panther_gazebo/README.md
+++ b/panther_gazebo/README.md
@@ -11,7 +11,7 @@ The package contains a launch file and source files used to run the robot simula
 
 ## Usage
 
-The recommended method for launching the simulation is by utilizing the [simulation.launch.py](https://github.com/husarion/panther_ros/panther_gazebo/launch/simulation.launch.py) file. Below, you will find launch arguments that enable simulation configuration. You can also launch more robots using `spawn.launch.py` ​​after the system has been started.
+The recommended method for launching the simulation is by utilizing the [simulation.launch.py](../panther_gazebo/launch/simulation.launch.py) file. Below, you will find launch arguments that enable simulation configuration. You can also launch more robots using `spawn.launch.py` ​​after the system has been started.
 
 ### Launch Arguments
 
@@ -35,7 +35,7 @@ The recommended method for launching the simulation is by utilizing the [simulat
 
 ### Changing Wheel Type
 
-It is possible to change Panther wheels model in simulation. All you need to do is to point to new wheel and controller configuration files using `wheel_config_path` and `controller_config_path` parameters. These files should be based on the default ones, i.e., [WH01_controller.yaml](https://github.com/husarion/panther_ros/panther_controller/config/WH01_controller.yaml) and [WH01.yaml](https://github.com/husarion/panther_ros/panther_description/config/WH01.yaml).
+It is possible to change Panther wheels model in simulation. All you need to do is to point to new wheel and controller configuration files using `wheel_config_path` and `controller_config_path` parameters. These files should be based on the default ones, i.e., [WH01_controller.yaml](../panther_controller/config/WH01_controller.yaml) and [WH01.yaml](../panther_description/config/WH01.yaml).
 
 ### Linear Battery Plugin
 
@@ -74,7 +74,7 @@ The NavSat sensors requires the spherical coordinates of the world origin to be 
 
 To obtain GPS data in Ignition, follow these steps:
 
-- Include the [ANT02](https://github.com/husarion/ros_components_description/blob/ros2/urdf/external_antenna.urdf.xacro) by adding the following lines to your [components.yaml](https://github.com/husarion/panther_ros/blob/ros2/panther_description/config/components.yaml) file inside the `components` list:
+- Include the [ANT02](https://github.com/husarion/ros_components_description/blob/ros2/urdf/external_antenna.urdf.xacro) by adding the following lines to your [components.yaml](../panther_description/config/components.yaml) file inside the `components` list:
 
 ```yaml
   - type: ANT02

--- a/panther_hardware_interfaces/README.md
+++ b/panther_hardware_interfaces/README.md
@@ -58,7 +58,7 @@ That said apart from the usual interface provided by the ros2_control, this plug
 
 [//]: # (ROS_API_NODE_PARAMETERS_START)
 
-Parameters that are required, are defined when including interface in URDF (you can check out [panther_macro.urdf.xacro](https://github.com/husarion/panther_ros/panther_description/urdf/panther_macro.urdf.xacro)).
+Parameters that are required, are defined when including interface in URDF (you can check out [panther_macro.urdf.xacro](../panther_description/urdf/panther_macro.urdf.xacro)).
 
 Physical properties
 
@@ -71,9 +71,9 @@ Physical properties
 CAN settings
 
 - `can_interface_name` [*string*, default: **panther_can**]: name of the CAN interface.
-- `master_can_id` [*int*, default: **3**]: CAN ID of the master device (set as in [canopen_configuration.yaml](https://github.com/husarion/panther_ros/panther_hardware_interfaces/config/canopen_configuration.yaml)).
-- `front_driver_can_id` [*int*, default: **1**]: CAN ID defined in the properties of Roboteq (set as in [canopen_configuration.yaml](https://github.com/husarion/panther_ros/panther_hardware_interfaces/config/canopen_configuration.yaml)).
-- `rear_driver_can_id` [*int*, default: **2**]: CAN ID defined in the properties of Roboteq (set as in [canopen_configuration.yaml](https://github.com/husarion/panther_ros/panther_hardware_interfaces/config/canopen_configuration.yaml)).
+- `master_can_id` [*int*, default: **3**]: CAN ID of the master device (set as in [canopen_configuration.yaml](../panther_hardware_interfaces/config/canopen_configuration.yaml)).
+- `front_driver_can_id` [*int*, default: **1**]: CAN ID defined in the properties of Roboteq (set as in [canopen_configuration.yaml](../panther_hardware_interfaces/config/canopen_configuration.yaml)).
+- `rear_driver_can_id` [*int*, default: **2**]: CAN ID defined in the properties of Roboteq (set as in [canopen_configuration.yaml](../panther_hardware_interfaces/config/canopen_configuration.yaml)).
 - `sdo_operation_timeout_ms` [*int*, default: **100**]: timeout of the SDO operations, currently no SDO operation is required in RT operation, so this timeout can be set to a higher value.
 - `pdo_motor_states_timeout_ms` [*int*, default: **15**]: depends on the frequency at which Roboteq is configured to send motor states (PDO 1 and 2) data. By default, there should be 10 **[ms]** between received data, if it takes more than `pdo_motor_states_timeout_ms`, a motor states read error is triggered. The default value is set to be expected period +50% margin.
 - `pdo_driver_state_timeout_ms` [*int*, default: **75**]: depends on the frequency at which Roboteq is configured to send driver state (PDO 3 and 4) data. By default, there should be 50 **[ms]** between received data, if it takes more than `pdo_driver_state_timeout_ms`, a driver state read error is triggered. The default value is set to be expected period +50% margin.
@@ -98,7 +98,7 @@ CAN settings
 [//]: # (ROS_API_NODE_DESCRIPTION_START)
 
 This package doesn't contain any standalone nodes - `PantherImuSensor` is a plugin loaded by the resource manager.
-To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](https://github.com/husarion/panther_ros/tree/ros2-devel/panther_description/)) and add an `imu_sensor_broadcaster` controller (example configuration provided in [panther_controller](https://github.com/husarion/panther_ros/tree/ros2-devel/panther_controller/) package).
+To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](../panther_description/)) and add an `imu_sensor_broadcaster` controller (example configuration provided in [panther_controller](../panther_controller/) package).
 
 [//]: # (ROS_API_NODE_DESCRIPTION_END)
 
@@ -106,7 +106,7 @@ To use this hardware interface you have to add it to your URDF (you can check ho
 
 [//]: # (ROS_API_NODE_PARAMETERS_START)
 
-Parameters that are required, are defined when including interface in URDF (you can check out [panther_macro.urdf.xacro](https://github.com/husarion/panther_ros/tree/ros2-devel/panther_description/urdf/panther_macro.urdf.xacro)).
+Parameters that are required, are defined when including interface in URDF (you can check out [panther_macro.urdf.xacro](../panther_description/urdf/panther_macro.urdf.xacro)).
 
 Physical properties
 
@@ -170,7 +170,7 @@ zeta = sqrt(3/4)* gyroMeasDrift = 0.00151
 
 ## Code structure
 
-The code structure is described in more detail in a [separate file](https://github.com/husarion/panther_ros/panther_hardware_interfaces/CODE_STRUCTURE.md).
+The code structure is described in more detail in a [separate file](../panther_hardware_interfaces/CODE_STRUCTURE.md).
 
 ## Generating CAN config
 

--- a/panther_hardware_interfaces/README.md
+++ b/panther_hardware_interfaces/README.md
@@ -23,7 +23,7 @@ Package that implements SystemInterface from ros2_control for Panther.
 [//]: # (ROS_API_NODE_DESCRIPTION_START)
 
 This package doesn't contain any standalone nodes - `PantherSystem` is a plugin loaded by the resource manager.
-To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](/panther_description)) and add a controller (example configuration provided in [panther_controller](/panther_controller) package).
+To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](../panther_description)) and add a controller (example configuration provided in [panther_controller](../panther_controller) package).
 That said apart from the usual interface provided by the ros2_control, this plugin also provides additional published topics and services specific for Panther.
 
 [//]: # (ROS_API_NODE_DESCRIPTION_END)

--- a/panther_hardware_interfaces/README.md
+++ b/panther_hardware_interfaces/README.md
@@ -23,7 +23,7 @@ Package that implements SystemInterface from ros2_control for Panther.
 [//]: # (ROS_API_NODE_DESCRIPTION_START)
 
 This package doesn't contain any standalone nodes - `PantherSystem` is a plugin loaded by the resource manager.
-To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](https://github.com/husarion/panther_ros/panther_description/)) and add a controller (example configuration provided in [panther_controller](https://github.com/husarion/panther_ros/panther_controller/) package).
+To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](panther_description/)) and add a controller (example configuration provided in [panther_controller](panther_controller/) package).
 That said apart from the usual interface provided by the ros2_control, this plugin also provides additional published topics and services specific for Panther.
 
 [//]: # (ROS_API_NODE_DESCRIPTION_END)

--- a/panther_hardware_interfaces/README.md
+++ b/panther_hardware_interfaces/README.md
@@ -23,7 +23,7 @@ Package that implements SystemInterface from ros2_control for Panther.
 [//]: # (ROS_API_NODE_DESCRIPTION_START)
 
 This package doesn't contain any standalone nodes - `PantherSystem` is a plugin loaded by the resource manager.
-To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](panther_description/)) and add a controller (example configuration provided in [panther_controller](panther_controller/) package).
+To use this hardware interface you have to add it to your URDF (you can check how to do it in [panther_description](/panther_description)) and add a controller (example configuration provided in [panther_controller](/panther_controller) package).
 That said apart from the usual interface provided by the ros2_control, this plugin also provides additional published topics and services specific for Panther.
 
 [//]: # (ROS_API_NODE_DESCRIPTION_END)

--- a/panther_lights/README.md
+++ b/panther_lights/README.md
@@ -160,15 +160,15 @@ Default animations can be found in the table below:
 
 |  ID   | NAME              | PRIORITY | ANIMATION                                                                                                           |
 | :---: | ----------------- | :------: | --------------------------------------------------------------------------------------------------------------------- |
-|   0   | E_STOP            |    3     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/E_STOP.webp" width="400">            |
-|   1   | READY             |    3     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/READY.webp" width="400">             |
-|   2   | ERROR             |    1     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/ERROR.webp" width="400">             |
-|   3   | MANUAL_ACTION     |    3     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/MANUAL_ACTION.webp" width="400">     |
-|   4   | AUTONOMOUS_ACTION |    3     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/AUTONOMOUS_ACTION.webp" width="400"> |
-|   5   | GOAL_ACHIEVED     |    2     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/GOAL_ACHIEVED.webp" width="400">     |
-|   6   | LOW_BATTERY       |    2     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/LOW_BATTERY.webp" width="400">       |
-|   7   | CRITICAL_BATTERY  |    2     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/CRITICAL_BATTERY.webp" width="400">  |
-|   9   | CHARGING_BATTERY  |    3     | <img src="https://github.com/husarion/panther_ros/blob/ros2/panther_lights/.docs/CHARGING_BATTERY.webp" width="400">  |
+|   0   | E_STOP            |    3     | <img src="../panther_lights/.docs/E_STOP.webp" width="400">            |
+|   1   | READY             |    3     | <img src="../panther_lights/.docs/READY.webp" width="400">             |
+|   2   | ERROR             |    1     | <img src="../panther_lights/.docs/ERROR.webp" width="400">             |
+|   3   | MANUAL_ACTION     |    3     | <img src="../panther_lights/.docs/MANUAL_ACTION.webp" width="400">     |
+|   4   | AUTONOMOUS_ACTION |    3     | <img src="../panther_lights/.docs/AUTONOMOUS_ACTION.webp" width="400"> |
+|   5   | GOAL_ACHIEVED     |    2     | <img src="../panther_lights/.docs/GOAL_ACHIEVED.webp" width="400">     |
+|   6   | LOW_BATTERY       |    2     | <img src="../panther_lights/.docs/LOW_BATTERY.webp" width="400">       |
+|   7   | CRITICAL_BATTERY  |    2     | <img src="../panther_lights/.docs/CRITICAL_BATTERY.webp" width="400">  |
+|   9   | CHARGING_BATTERY  |    3     | <img src="../panther_lights/.docs/CHARGING_BATTERY.webp" width="400">  |
 
 ### Animation Types
 


### PR DESCRIPTION
### Description

Links in `README.md` files are absolute and some of them don't work.

### Modifications

Changed absolute links in `*.md` files from .eg `[panther_description](https://github.com/husarion/panther_ros/panther_description/)` to `[panther_description](../panther_description/)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation across multiple components to use relative paths for links, enhancing portability and usability for users navigating the project structure.
	- Adjusted image source paths in the `panther_lights` documentation to relative links, improving accessibility regardless of hosting environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->