### PR TITLE
Ros2 readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ rosdep update --rosdistro $ROS_DISTRO
 rosdep install --from-paths src -y -i
 
 source /opt/ros/$ROS_DISTRO/setup.bash
-colcon build --symlink-install --packages-up-to husarion_ugv --cmake-args -DCMAKE_BUILD_TYPE=Release
+colcon build --symlink-install --packages-up-to husarion_ugv --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
 
 source install/setup.bash
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ROS 2 packages for Husarion UGV (Unmanned Ground Vehicle). The repository is a c
 ```bash
 mkdir ~/husarion_ws
 cd ~/husarion_ws
-git clone -b ros2 https://github.com/husarion/panther_ros.git src/husarion_ugv
+git clone -b ros2 https://github.com/husarion/panther_ros.git src/husarion_ugv_ros
 ```
 
 ### Configure environment
@@ -38,9 +38,8 @@ export HUSARION_ROS_BUILD_TYPE=simulation
 ### Build
 
 ``` bash
-vcs import src < src/husarion_ugv/husarion_ugv/${HUSARION_ROS_BUILD_TYPE}_deps.repos
+vcs import src < src/husarion_ugv_ros/husarion_ugv/${HUSARION_ROS_BUILD_TYPE}_deps.repos
 
-cp -r src/ros2_controllers/diff_drive_controller src
 cp -r src/ros2_controllers/imu_sensor_broadcaster src
 rm -rf src/ros2_controllers
 

--- a/docker/Dockerfile.hardware
+++ b/docker/Dockerfile.hardware
@@ -16,7 +16,6 @@ RUN apt-get update  && \
         ros-dev-tools && \
     # Setup workspace
     vcs import src < src/husarion_ugv/husarion_ugv/${HUSARION_ROS_BUILD_TYPE}_deps.repos && \
-    cp -r src/ros2_controllers/diff_drive_controller src && \
     cp -r src/ros2_controllers/imu_sensor_broadcaster src && \
     rm -rf src/ros2_controllers && \
     # Install dependencies

--- a/docker/Dockerfile.simulation
+++ b/docker/Dockerfile.simulation
@@ -17,7 +17,6 @@ RUN apt-get update  && \
         ros-dev-tools && \
     # Setup workspace
     vcs import src < src/husarion_ugv/husarion_ugv/${HUSARION_ROS_BUILD_TYPE}_deps.repos && \
-    cp -r src/ros2_controllers/diff_drive_controller src && \
     cp -r src/ros2_controllers/imu_sensor_broadcaster src && \
     rm -rf src/ros2_controllers && \
     # Install dependencies

--- a/husarion_ugv_description/launch/rviz.launch.py
+++ b/husarion_ugv_description/launch/rviz.launch.py
@@ -54,7 +54,7 @@ def generate_launch_description():
         choices=["True", "true", "False", "false"],
     )
 
-    ns_ext = PythonExpression(["'' if '", namespace, "' else '", namespace, "' + '/'"])
+    ns_ext = PythonExpression(["'", namespace, "' + '/' if '", namespace, "' else ''"])
 
     rviz_config = ReplaceString(
         source_file=rviz_config,

--- a/husarion_ugv_description/rviz/husarion_ugv.rviz
+++ b/husarion_ugv_description/rviz/husarion_ugv.rviz
@@ -42,10 +42,10 @@ Visualization Manager:
           Offset:
             X: 0
             Y: 0
-            Z: 0
+            Z: -0.18
           Plane: XY
           Plane Cell Count: 10
-          Reference Frame: <namespace>/base_footprint
+          Reference Frame: <Fixed Frame>
           Value: true
       Enabled: true
       Name: Map


### PR DESCRIPTION
### Description

- Remove building diff_drive after humble sync with https://github.com/ros-controls/ros2_controllers/pull/1420
- Fix `rviz.launch.py` namespace prefixes

### Requirements

- [x] Code style guidelines followed
- [x] Documentation updated

### Tests 🧪

- [ ] Robot
- [ ] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation**
  - Updated README with corrected repository name and import paths
  - Modified repository cloning instructions

- **Configuration**
  - Removed `diff_drive_controller` from Docker build process for hardware and simulation environments
  - Updated RViz configuration:
    - Adjusted grid vertical positioning
    - Changed grid reference frame

- **Minor Improvements**
  - Refined namespace handling in launch configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->