### PR TITLE
E-Stop GUI reacts to changing e_stop state

### DIFF
--- a/husarion_ugv_gazebo/CMakeLists.txt
+++ b/husarion_ugv_gazebo/CMakeLists.txt
@@ -44,7 +44,7 @@ qt5_add_resources(resources_rcc src/gui/EStop.qrc)
 
 add_library(EStop SHARED include/husarion_ugv_gazebo/gui/e_stop.hpp
                          src/gui/e_stop.cpp ${resources_rcc})
-ament_target_dependencies(EStop rclcpp std_srvs)
+ament_target_dependencies(EStop rclcpp std_msgs std_srvs)
 target_link_libraries(
   EStop
   ignition-gazebo6

--- a/husarion_ugv_gazebo/include/husarion_ugv_gazebo/gui/e_stop.hpp
+++ b/husarion_ugv_gazebo/include/husarion_ugv_gazebo/gui/e_stop.hpp
@@ -17,10 +17,10 @@
 
 #include <string>
 
-#include <ignition/gui/qt.h>
 #include <ignition/gui/Plugin.hh>
 #include <rclcpp/rclcpp.hpp>
 
+#include <std_msgs/msg/bool.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
 namespace husarion_ugv_gazebo
@@ -30,35 +30,46 @@ class EStop : public ignition::gui::Plugin
 {
   Q_OBJECT
 
-  Q_PROPERTY(QString ns READ GetNamespace WRITE SetNamespace NOTIFY ChangedNamespace)
-
 public:
   EStop();
-  virtual ~EStop();
+  ~EStop();
   void LoadConfig(const tinyxml2::XMLElement * plugin_elem) override;
-  Q_INVOKABLE QString GetNamespace() const;
 
-public slots:
-  void SetNamespace(const QString & ns);
+  Q_INVOKABLE void ButtonPressed(bool checked);
+
+  Q_PROPERTY(bool e_stop READ IsEStop WRITE SetEStop NOTIFY OnEStopChange)
+  bool IsEStop() const { return e_stop_; }
+  void SetEStop(bool value);
+
+  Q_PROPERTY(QString ns READ GetNamespace WRITE SetNamespace NOTIFY OnNamespaceChange)
+  QString GetNamespace() const { return QString::fromStdString(namespace_); }
+  Q_INVOKABLE void SetNamespace(const QString & ns);
 
 signals:
-  void ChangedNamespace();
-
-protected slots:
-  void ButtonPressed(bool pressed);
+  void OnEStopChange();
+  void OnNamespaceChange();
 
 private:
-  static constexpr char kDefaultEStopResetService[] = "/hardware/e_stop_reset";
-  static constexpr char kDefaultEStopTriggerService[] = "/hardware/e_stop_trigger";
+  void OnEStopStatus(const std_msgs::msg::Bool::SharedPtr msg);
 
+  static constexpr char kDefaultTopicName[] = "/hardware/e_stop";
+  static constexpr char kDefaultResetSrvName[] = "/hardware/e_stop_reset";
+  static constexpr char kDefaultTriggerSrvName[] = "/hardware/e_stop_trigger";
+  const rclcpp::QoS e_stop_qos_ = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
+
+  bool e_stop_ = true;
   std::string namespace_ = "";
-  std::string e_stop_reset_service_ = kDefaultEStopResetService;
-  std::string e_stop_trigger_service_ = kDefaultEStopTriggerService;
+  std::string topic_name_ = kDefaultTopicName;
+  std::string reset_srv_name_ = kDefaultResetSrvName;
+  std::string trigger_srv_name_ = kDefaultTriggerSrvName;
 
   rclcpp::Node::SharedPtr node_;
+
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr e_stop_sub_;
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr e_stop_reset_client_;
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr e_stop_trigger_client_;
 };
+
 }  // namespace husarion_ugv_gazebo
 
 #endif  // HUSARION_UGV_GAZEBO_GUI_E_STOP_HPP_

--- a/husarion_ugv_gazebo/src/gui/EStop.qml
+++ b/husarion_ugv_gazebo/src/gui/EStop.qml
@@ -62,27 +62,27 @@ Rectangle {
     anchors.topMargin: 10
     anchors.horizontalCenter: widgetRectangle.horizontalCenter
     checkable: true
-    checked: false
+    checked: EStop.checked
     width: 100
     height: 100
     contentItem: Rectangle {
       width: parent.width
       height: parent.height
       radius: 50
-      color: eStopButton.checked ? "#d70000" : "#66b849"
+      color: EStop.e_stop ? "#66b849" : "#d70000"
       border.width: 2
       border.color: "#909090"
 
       Text {
         anchors.centerIn: parent
-        text: eStopButton.checked ? "STOP" : "GO"
+        text: EStop.e_stop ? "GO" : "STOP"
         font.bold: true
         color: "white"
         font.pixelSize: 24
       }
     }
     onPressed: {
-      EStop.ButtonPressed(eStopButton.checked);
+      EStop.ButtonPressed(EStop.e_stop);
     }
   }
 }

--- a/husarion_ugv_gazebo/src/gui/e_stop.cpp
+++ b/husarion_ugv_gazebo/src/gui/e_stop.cpp
@@ -14,28 +14,30 @@
 
 #include "husarion_ugv_gazebo/gui/e_stop.hpp"
 
-#include <memory>
-
+#include <ignition/common/Console.hh>
 #include <ignition/gui/Application.hh>
-#include <ignition/gui/MainWindow.hh>
 #include <ignition/plugin/Register.hh>
-#include <rclcpp/rclcpp.hpp>
-
-#include <std_srvs/srv/trigger.hpp>
 
 namespace husarion_ugv_gazebo
 {
 
-EStop::EStop() : ignition::gui::Plugin() { rclcpp::init(0, nullptr); }
+EStop::EStop() : ignition::gui::Plugin()
+{
+  rclcpp::init(0, nullptr);
+  node_ = std::make_shared<rclcpp::Node>("gz_estop_gui");
+
+  e_stop_sub_ = node_->create_subscription<std_msgs::msg::Bool>(
+    topic_name_, e_stop_qos_, std::bind(&EStop::OnEStopStatus, this, std::placeholders::_1));
+  e_stop_reset_client_ = node_->create_client<std_srvs::srv::Trigger>(reset_srv_name_);
+  e_stop_trigger_client_ = node_->create_client<std_srvs::srv::Trigger>(trigger_srv_name_);
+
+  std::thread([this]() { rclcpp::spin(node_); }).detach();
+}
 
 EStop::~EStop() { rclcpp::shutdown(); }
 
 void EStop::LoadConfig(const tinyxml2::XMLElement * plugin_elem)
 {
-  node_ = rclcpp::Node::make_shared("gz_estop_gui");
-  e_stop_reset_client_ = node_->create_client<std_srvs::srv::Trigger>(e_stop_reset_service_);
-  e_stop_trigger_client_ = node_->create_client<std_srvs::srv::Trigger>(e_stop_trigger_service_);
-
   if (title.empty()) {
     title = "E-stop";
   }
@@ -48,47 +50,52 @@ void EStop::LoadConfig(const tinyxml2::XMLElement * plugin_elem)
   }
 }
 
-void EStop::ButtonPressed(bool pressed)
+void EStop::ButtonPressed(bool e_stop)
 {
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
-
-  auto client = pressed ? e_stop_trigger_client_ : e_stop_reset_client_;
+  auto client = e_stop ? e_stop_reset_client_ : e_stop_trigger_client_;
 
   if (!client->service_is_ready()) {
-    ignwarn << "Unavailable service: "
-            << (pressed ? e_stop_reset_service_ : e_stop_trigger_service_) << std::endl;
+    ignwarn << "Unavailable service: " << (e_stop ? reset_srv_name_ : trigger_srv_name_)
+            << std::endl;
     return;
   }
-
   auto result_future = client->async_send_request(request);
-  if (
-    rclcpp::spin_until_future_complete(node_, result_future, std::chrono::seconds(1)) !=
-    rclcpp::FutureReturnCode::SUCCESS) {
-    ignwarn << "Failed to call service '" << client->get_service_name() << "'!" << std::endl;
-    return;
-  }
 
-  const auto result = result_future.get();
-  if (!result->success) {
-    ignwarn << "Service call did not succeed: " << result->message << std::endl;
+  try {
+    const auto result = result_future.get();
+    if (!result->success) {
+      ignwarn << "Service call did not succeed: " << result->message << std::endl;
+    }
+  } catch (const std::exception & e) {
+    ignerr << "Exception while waiting for service response: " << e.what() << std::endl;
   }
-  ignmsg << "EStop: " << result->message << std::endl;
 }
-
-QString EStop::GetNamespace() const { return QString::fromStdString(namespace_); }
 
 void EStop::SetNamespace(const QString & ns)
 {
   namespace_ = ns.toStdString();
-  e_stop_reset_service_ = namespace_ + kDefaultEStopResetService;
-  e_stop_trigger_service_ = namespace_ + kDefaultEStopTriggerService;
 
-  e_stop_reset_client_ = node_->create_client<std_srvs::srv::Trigger>(e_stop_reset_service_);
-  e_stop_trigger_client_ = node_->create_client<std_srvs::srv::Trigger>(e_stop_trigger_service_);
+  topic_name_ = namespace_ + kDefaultTopicName;
+  reset_srv_name_ = namespace_ + kDefaultResetSrvName;
+  trigger_srv_name_ = namespace_ + kDefaultTriggerSrvName;
 
-  ChangedNamespace();
-  ignmsg << "Changed namespace to: " << namespace_ << std::endl;
+  e_stop_sub_ = node_->create_subscription<std_msgs::msg::Bool>(
+    topic_name_, e_stop_qos_, std::bind(&EStop::OnEStopStatus, this, std::placeholders::_1));
+  e_stop_reset_client_ = node_->create_client<std_srvs::srv::Trigger>(reset_srv_name_);
+  e_stop_trigger_client_ = node_->create_client<std_srvs::srv::Trigger>(trigger_srv_name_);
+
+  emit OnNamespaceChange();
+  ignmsg << "Namespace changed to: " << namespace_ << std::endl;
 }
+
+void EStop::SetEStop(bool value)
+{
+  e_stop_ = value;
+  emit OnEStopChange();
+}
+
+void EStop::OnEStopStatus(const std_msgs::msg::Bool::SharedPtr msg) { SetEStop(msg->data); }
 
 }  // namespace husarion_ugv_gazebo
 


### PR DESCRIPTION
### Description

- External changes to the e_stopa state are now logged and change the GUI state

### Requirements

- [x] Code style guidelines followed
- [x] Documentation updated

### Tests 🧪

- [ ] Robot
- [ ] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced emergency stop (E-Stop) functionality with improved state management
	- Added dynamic button state tracking for E-Stop control

- **Bug Fixes**
	- Improved error handling for service interactions
	- Updated service client logic for more robust emergency stop management

- **Refactor**
	- Restructured E-Stop class methods and properties
	- Updated dependency management for E-Stop library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->