### PR TITLE
Ros2 expot test directory

### DIFF
--- a/husarion_ugv_manager/CMakeLists.txt
+++ b/husarion_ugv_manager/CMakeLists.txt
@@ -118,7 +118,9 @@ install(DIRECTORY behavior_trees config launch
 
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
-install(DIRECTORY test/ DESTINATION include/${PROJECT_NAME}/test/)
+# To be able to access the test utils files by `husarion_ugv_manager/test/**` instead of `test/**`
+install(DIRECTORY test/
+        DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}/test/)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/husarion_ugv_manager/CMakeLists.txt
+++ b/husarion_ugv_manager/CMakeLists.txt
@@ -118,9 +118,9 @@ install(DIRECTORY behavior_trees config launch
 
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
-# To be able to access the test utils files by `husarion_ugv_manager/test/**` instead of `test/**`
-install(DIRECTORY test/
-        DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}/test/)
+# Access via `husarion_ugv_manager/test/**` instead of `test/**`
+install(DIRECTORY test/utils
+        DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}/test/utils)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/husarion_ugv_manager/CMakeLists.txt
+++ b/husarion_ugv_manager/CMakeLists.txt
@@ -119,7 +119,7 @@ install(DIRECTORY behavior_trees config launch
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # Access via `husarion_ugv_manager/test/**` instead of `test/**`
-install(DIRECTORY test/utils
+install(DIRECTORY test/utils/
         DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME}/test/utils)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
### Description

- In the `husarion_ugv_autonomy_ros` package we have plugins that we would like to test using files from `husarion_manager/test/utils`. However, the `test` folder, unlike `include`, does not have a subdirectory with the `project name`, so I suggest making a correction in cmake.

### Requirements

- [x] Code style guidelines followed
- [x] Documentation updated

### Tests 🧪

- [x] Build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated test directory installation configuration in CMakeLists.txt
	- Refined test utilities installation path

<!-- end of auto-generated comment: release notes by coderabbit.ai -->