### PR TITLE
Adjust wheel_separation_multiplier

### DIFF
--- a/husarion_ugv_controller/config/WH05_controller.yaml
+++ b/husarion_ugv_controller/config/WH05_controller.yaml
@@ -34,7 +34,7 @@
 
       # For skid drive kinematics it will act as ICR coefficient, kinematic model with ICR
       # coefficient isn't totally accurate and this coefficient can differ for various ground types
-      wheel_separation_multiplier: 1.5
+      wheel_separation_multiplier: 1.37
 
       left_wheel_radius_multiplier: 1.0
       right_wheel_radius_multiplier: 1.0


### PR DESCRIPTION
### Description

- Adjust wheel_separation_multiplier for better odometry

### Requirements

- [x] Code style guidelines followed
- [x] Documentation updated

### Tests 🧪

- [x] Robot
- [x] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
  - Adjusted wheel separation multiplier from 1.5 to 1.37 to improve robot movement precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->