### PR TITLE
Fix reusable workflow

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -4,11 +4,19 @@ name: Build Docker
 on:
   workflow_call:
     inputs:
+      branch_name:
+        description: Tag used in the docker image (branch/tag/commit).
+        required: true
+        type: string
+        default: ros2-devel
       build_type:
         description: Is it a "development" or a "stable" release?
         required: true
-        type: string
+        type: choice
         default: development
+        options:
+          - development
+          - stable
       target_distro:
         description: In case of "stable" release specify the ROS distro of the existing docker image (eg.
           humble)
@@ -76,6 +84,7 @@ jobs:
           main_branch_name: ros2
           dockerfile: ${{ matrix.dockerfile }}
           repo_name: ${{ matrix.repo_name }}
+          branch_name: ${{ inputs.branch_name }}
           build_type: ${{ inputs.build_type }}
           ros_distro: ${{ matrix.ros_distro }}
           platforms: ${{ matrix.platforms }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -12,11 +12,8 @@ on:
       build_type:
         description: Is it a "development" or a "stable" release?
         required: true
-        type: choice
+        type: string
         default: development
-        options:
-          - development
-          - stable
       target_distro:
         description: In case of "stable" release specify the ROS distro of the existing docker image (eg.
           humble)

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -8,7 +8,6 @@ on:
         description: Tag used in the docker image (branch/tag/commit).
         required: true
         type: string
-        default: ros2-devel
       build_type:
         description: Is it a "development" or a "stable" release?
         required: true

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -56,14 +56,14 @@ jobs:
           message: Update tags in compose files
           author_name: action-bot
           author_email: action-bot@action-bot.com
-          new_branch: ${{ inputs.version }}-${{ inputs.date }}
+          new_branch: ${{ env.RC_BRANCH_NAME }}
 
   build_docker:
     name: Build Docker
     needs: update_compose_files
     uses: ./.github/workflows/build-docker.yaml
     with:
-      branch_name: ${{ env.RC_BRANCH_NAME }}
+      branch_name: ${{ inputs.version }}-${{ inputs.date }}
       build_type: development
   os_image:
     name: OS image

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -60,7 +60,7 @@ jobs:
           new_branch: ${{ env.RC_BRANCH_NAME }}
 
       - name: Build Docker
-        uses: .github/workflows/build-docker.yaml
+        uses: husarion/panther_ros/.github/workflows/build-docker.yaml@ros2
         with:
           build_type: development
 

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -65,6 +65,7 @@ jobs:
     with:
       branch_name: ${{ inputs.version }}-${{ inputs.date }}
       build_type: development
+
   os_image:
     name: OS image
     needs: update_compose_files

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -60,7 +60,7 @@ jobs:
           new_branch: ${{ env.RC_BRANCH_NAME }}
 
       - name: Build Docker
-        uses: ./.github/workflows/build-docker.yaml
+        uses: .github/workflows/build-docker.yaml@${{ github.ref_name }}
         with:
           build_type: development
 

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -12,7 +12,7 @@ on:
         required: true
 
 env:
-  RC_BRANCH_NAME: ${{ github.event.inputs.version }}-${{ github.event.inputs.date }}
+  RC_BRANCH_NAME: ${{ inputs.version }}-${{ inputs.date }}
 
 jobs:
   docs:
@@ -56,7 +56,7 @@ jobs:
           message: Update tags in compose files
           author_name: action-bot
           author_email: action-bot@action-bot.com
-          new_branch: ${{ env.RC_BRANCH_NAME }}
+          new_branch: ${{ inputs.version }}-${{ inputs.date }}
 
   build_docker:
     name: Build Docker
@@ -91,7 +91,7 @@ jobs:
             {
               "dev_image": "true",
               "husarion_ugv_version": "${{ env.RC_BRANCH_NAME }}",
-              "image_tag": "${{ github.event.inputs.version }}"
+              "image_tag": "${{ inputs.version }}"
             }
 
       - name: Build flash OS image
@@ -104,5 +104,5 @@ jobs:
           ref: ${{ env.RC_BRANCH_NAME }}
           client_payload: |
             {
-              "image_tag": "${{ github.event.inputs.version }}"
+              "image_tag": "${{ inputs.version }}"
             }

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -60,7 +60,7 @@ jobs:
           new_branch: ${{ env.RC_BRANCH_NAME }}
 
       - name: Build Docker
-        uses: .github/workflows/build-docker.yaml@${{ github.ref_name }}
+        uses: .github/workflows/build-docker.yaml@${{ github.ref }}
         with:
           build_type: development
 

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -60,7 +60,7 @@ jobs:
           new_branch: ${{ env.RC_BRANCH_NAME }}
 
       - name: Build Docker
-        uses: .github/workflows/build-docker.yaml@ros2
+        uses: .github/workflows/build-docker.yaml
         with:
           build_type: development
 

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -60,7 +60,7 @@ jobs:
           new_branch: ${{ env.RC_BRANCH_NAME }}
 
       - name: Build Docker
-        uses: .github/workflows/build-docker.yaml@${{ github.ref }}
+        uses: .github/workflows/build-docker.yaml@ros2
         with:
           build_type: development
 

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -29,7 +29,6 @@ jobs:
           ref: master
           client_payload: '{"husarion_ugv_branch": "ros2-devel"}'
 
-  # TODO: Add unit testing when ready
   unit_tests:
     name: Unit tests
     runs-on: ubuntu-22.04
@@ -37,8 +36,8 @@ jobs:
       - name: Run unit tests
         run: echo "Unit tests are not fully implemented yet -> SKIPPING!"
 
-  docker:
-    name: Docker
+  update_compose_files:
+    name: Update compose files
     needs: unit_tests
     runs-on: ubuntu-22.04
     steps:
@@ -59,14 +58,16 @@ jobs:
           author_email: action-bot@action-bot.com
           new_branch: ${{ env.RC_BRANCH_NAME }}
 
-      - name: Build Docker
-        uses: husarion/panther_ros/.github/workflows/build-docker.yaml@ros2
-        with:
-          build_type: development
-
+  build_docker:
+    name: Build Docker
+    needs: update_compose_files
+    uses: .github/workflows/build-docker.yaml
+    with:
+      branch_name: ${{ env.RC_BRANCH_NAME }}
+      build_type: development
   os_image:
     name: OS image
-    needs: docker
+    needs: update_compose_files
     runs-on: ubuntu-22.04
     steps:
       - name: Create new branch

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -61,7 +61,7 @@ jobs:
   build_docker:
     name: Build Docker
     needs: update_compose_files
-    uses: .github/workflows/build-docker.yaml
+    uses: ./.github/workflows/build-docker.yaml
     with:
       branch_name: ${{ env.RC_BRANCH_NAME }}
       build_type: development

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -44,8 +44,7 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
 
       - name: Build Docker with new version
-        uses: .github/workflows/build-docker.yaml@ros2
-
+        uses: .github/workflows/build-docker.yaml
         with:
           build_type: development
 

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -44,7 +44,7 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
 
       - name: Build Docker with new version
-        uses: .github/workflows/build-docker.yaml@${{ github.ref_name }}
+        uses: .github/workflows/build-docker.yaml@${{ github.ref }}
 
         with:
           build_type: development

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -79,7 +79,7 @@ jobs:
             }
 
       - name: Build OS image
-        if: ${{ fromJSON(inputs.automatic_mode) == true }}
+        if: ${{ inputs.automatic_mode }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: husarion
@@ -95,7 +95,7 @@ jobs:
             }
 
       - name: Build flash OS image
-        if: ${{ fromJSON(inputs.automatic_mode) == true }}
+        if: ${{ inputs.automatic_mode }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: husarion

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -44,7 +44,7 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
 
       - name: Build Docker with new version
-        uses: .github/workflows/build-docker.yaml@${{ github.ref }}
+        uses: .github/workflows/build-docker.yaml@ros2
 
         with:
           build_type: development

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -26,7 +26,7 @@ on:
         description: Mark the release as a prerelease.
 
 env:
-  RC_BRANCH_NAME: ${{ github.event.inputs.version }}-${{ github.event.inputs.date }}
+  RC_BRANCH_NAME: ${{ inputs.version }}-${{ inputs.date }}
   MAIN_BRANCH: ros2
 
 jobs:
@@ -35,10 +35,10 @@ jobs:
     uses: ./.github/workflows/release-repository.yaml
     with:
       release_candidate: ${{ env.RC_BRANCH_NAME }}
-      version: ${{ github.event.inputs.version }}
-      release_name: ${{ github.event.inputs.release_name }}
-      automatic_mode: ${{ github.event.inputs.automatic_mode }}
-      prerelease: ${{ github.event.inputs.prerelease }}
+      version: ${{ inputs.version }}
+      release_name: ${{ inputs.release_name }}
+      automatic_mode: ${{ inputs.automatic_mode }}
+      prerelease: ${{ inputs.prerelease }}
 
   build_docker:
     name: Build Docker
@@ -54,8 +54,8 @@ jobs:
     with:
       build_type: stable
       target_distro: humble
-      target_release: ${{ github.event.inputs.version }}
-      target_date: ${{ github.event.inputs.date }}
+      target_release: ${{ inputs.version }}
+      target_date: ${{ inputs.date }}
 
   release_project:
     name: Release project
@@ -72,14 +72,14 @@ jobs:
           client_payload: |
             {
               "release_candidate": "${{ env.RC_BRANCH_NAME }}",
-              "version": "${{ github.event.inputs.version }}",
-              "release_name": "${{ github.event.inputs.release_name }}",
-              "automatic_mode": "${{ github.event.inputs.automatic_mode }}",
-              "prerelease": "${{ github.event.inputs.prerelease }}"
+              "version": "${{ inputs.version }}",
+              "release_name": "${{ inputs.release_name }}",
+              "automatic_mode": "${{ inputs.automatic_mode }}",
+              "prerelease": "${{ inputs.prerelease }}"
             }
 
       - name: Build OS image
-        if: ${{ fromJSON(github.event.inputs.automatic_mode) == true }}
+        if: ${{ fromJSON(inputs.automatic_mode) == true }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: husarion
@@ -90,12 +90,12 @@ jobs:
           client_payload: |
             {
               "dev_image": "false",
-              "husarion_ugv_version": "${{ github.event.inputs.version }}",
-              "image_tag": "${{ github.event.inputs.version }}"
+              "husarion_ugv_version": "${{ inputs.version }}",
+              "image_tag": "${{ inputs.version }}"
             }
 
       - name: Build flash OS image
-        if: ${{ fromJSON(github.event.inputs.automatic_mode) == true }}
+        if: ${{ fromJSON(inputs.automatic_mode) == true }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: husarion
@@ -105,7 +105,7 @@ jobs:
           ref: ${{ env.MAIN_BRANCH }}
           client_payload: |
             {
-              "image_tag": "${{ github.event.inputs.version }}"
+              "image_tag": "${{ inputs.version }}"
             }
 
   docs:

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -32,7 +32,7 @@ env:
 jobs:
   release_repository:
     name: Release repository
-    uses: .github/workflows/release-repository.yaml
+    uses: ./.github/workflows/release-repository.yaml
     with:
       release_candidate: ${{ env.RC_BRANCH_NAME }}
       version: ${{ github.event.inputs.version }}
@@ -43,14 +43,14 @@ jobs:
   build_docker:
     name: Build Docker
     needs: release_repository
-    uses: .github/workflows/build-docker.yaml
+    uses: ./.github/workflows/build-docker.yaml
     with:
       build_type: development
 
   tag_docker_as_stable:
     name: Tag Docker as stable
     needs: build_docker
-    uses: .github/workflows/build-docker.yaml
+    uses: ./.github/workflows/build-docker.yaml
     with:
       build_type: stable
       target_distro: humble

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -30,24 +30,37 @@ env:
   MAIN_BRANCH: ros2
 
 jobs:
+  release_repository:
+    name: Release repository
+    uses: .github/workflows/release-repository.yaml
+    with:
+      release_candidate: ${{ env.RC_BRANCH_NAME }}
+      version: ${{ github.event.inputs.version }}
+      release_name: ${{ github.event.inputs.release_name }}
+      automatic_mode: ${{ github.event.inputs.automatic_mode }}
+      prerelease: ${{ github.event.inputs.prerelease }}
+
+  build_docker:
+    name: Build Docker
+    needs: release_repository
+    uses: .github/workflows/build-docker.yaml
+    with:
+      build_type: development
+
+  tag_docker_as_stable:
+    name: Tag Docker as stable
+    needs: build_docker
+    uses: .github/workflows/build-docker.yaml
+    with:
+      build_type: stable
+      target_distro: humble
+      target_release: ${{ github.event.inputs.version }}
+      target_date: ${{ github.event.inputs.date }}
+
   release_project:
     name: Release project
     runs-on: ubuntu-22.04
     steps:
-      - name: Release repository
-        uses: ./.github/workflows/release-repository.yaml
-        with:
-          release_candidate: ${{ env.RC_BRANCH_NAME }}
-          version: ${{ github.event.inputs.version }}
-          release_name: ${{ github.event.inputs.release_name }}
-          automatic_mode: ${{ github.event.inputs.automatic_mode }}
-          prerelease: ${{ github.event.inputs.prerelease }}
-
-      - name: Build Docker with new version
-        uses: husarion/panther_ros/.github/workflows/build-docker.yaml@ros2
-        with:
-          build_type: development
-
       - name: Release panther-rpi-os-img repository
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -95,6 +108,10 @@ jobs:
               "image_tag": "${{ github.event.inputs.version }}"
             }
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-22.04
+    steps:
       - name: Rebuild documentation
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -44,7 +44,7 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
 
       - name: Build Docker with new version
-        uses: .github/workflows/build-docker.yaml
+        uses: husarion/panther_ros/.github/workflows/build-docker.yaml@ros2
         with:
           build_type: development
 

--- a/.github/workflows/release-project.yaml
+++ b/.github/workflows/release-project.yaml
@@ -44,7 +44,8 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
 
       - name: Build Docker with new version
-        uses: ./.github/workflows/build-docker.yaml
+        uses: .github/workflows/build-docker.yaml@${{ github.ref_name }}
+
         with:
           build_type: development
 

--- a/.github/workflows/release-repository.yaml
+++ b/.github/workflows/release-repository.yaml
@@ -38,13 +38,13 @@ jobs:
       - name: Checkout to rc branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.release_candidate }}
+          ref: ${{ inputs.release_candidate }}
 
       - name: Catkin release
         id: catkin_release
         uses: at-wat/catkin-release-action@v1
         with:
-          version: ${{ github.event.inputs.version }}
+          version: ${{ inputs.version }}
           git_user: action-bot
           git_email: action-bot@action-bot.com
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,13 +52,13 @@ jobs:
       - name: Catkin release - create PR
         run: |
           gh pr create \
-          --base ${{ github.event.inputs.release_candidate }} \
+          --base ${{ inputs.release_candidate }} \
           --head ${{ steps.catkin_release.outputs.created_branch }} \
           --title "Release ${{ steps.catkin_release.outputs.version}}" \
           --body "This PR incorporates package(s) version and changelog update."
 
       - name: Catkin release - merge PR
-        if: ${{ fromJSON(github.event.inputs.automatic_mode) == true }}
+        if: ${{ fromJSON(inputs.automatic_mode) == true }}
         run: |
           gh pr merge ${{ steps.catkin_release.outputs.created_branch }} \
           --merge --delete-branch
@@ -69,47 +69,45 @@ jobs:
           sudo chmod -R ugo+rwX .
 
       - name: Checkout to main branch
-        if: ${{ github.event.inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode)
-          == true }}
+        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true
+          }}
         uses: actions/checkout@v4
         with:
           ref: ${{ env.MAIN_BRANCH }}
           fetch-depth: 0
 
       - name: Create PR to main branch
-        if: ${{ github.event.inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode)
-          == true }}
+        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true
+          }}
         run: |
           gh pr create \
           --base ${{ env.MAIN_BRANCH }} \
-          --head ${{ github.event.inputs.release_candidate }} \
+          --head ${{ inputs.release_candidate }} \
           --title "Release ${{ steps.catkin_release.outputs.version}} to ${{ env.MAIN_BRANCH }}" \
           --body "This PR incorporates package(s) version and changelog update."
 
       - name: Merge PR to main branch
-        if: ${{ github.event.inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode)
-          == true }}
+        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true
+          }}
         run: |
-          gh pr merge ${{ github.event.inputs.release_candidate }} \
+          gh pr merge ${{ inputs.release_candidate }} \
           --merge --delete-branch
 
       - name: Create prerelease
-        if: ${{ fromJSON(github.event.inputs.automatic_mode) == true && fromJSON(github.event.inputs.prerelease)
-          == true}}
+        if: ${{ fromJSON(inputs.automatic_mode) == true && fromJSON(inputs.prerelease) == true}}
         run: |
           gh release create ${{ steps.catkin_release.outputs.version }} \
           --target ${{ env.MAIN_BRANCH }} \
-          --title ${{ github.event.inputs.release_name }} \
+          --title ${{ inputs.release_name }} \
           --generate-notes \
           --prerelease
 
       - name: Create release
-        if: ${{ fromJSON(github.event.inputs.automatic_mode) == true && fromJSON(github.event.inputs.prerelease)
-          == false}}
+        if: ${{ fromJSON(inputs.automatic_mode) == true && fromJSON(inputs.prerelease) == false}}
         run: |
           gh release create ${{ steps.catkin_release.outputs.version }} \
           --target ${{ env.MAIN_BRANCH }} \
-          --title ${{ github.event.inputs.release_name }} \
+          --title ${{ inputs.release_name }} \
           --generate-notes
 
       - name: Checkout to devel branch

--- a/.github/workflows/release-repository.yaml
+++ b/.github/workflows/release-repository.yaml
@@ -58,27 +58,25 @@ jobs:
           --body "This PR incorporates package(s) version and changelog update."
 
       - name: Catkin release - merge PR
-        if: ${{ fromJSON(inputs.automatic_mode) == true }}
+        if: ${{ inputs.automatic_mode }}
         run: |
           gh pr merge ${{ steps.catkin_release.outputs.created_branch }} \
           --merge --delete-branch
 
       - name: Grant permissions # Required permission grant after at-wat/catkin-release-action@v1 action
-        if: ${{ fromJSON(inputs.automatic_mode) == true }}
+        if: ${{ inputs.automatic_mode }}
         run: |
           sudo chmod -R ugo+rwX .
 
       - name: Checkout to main branch
-        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true
-          }}
+        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && inputs.automatic_mode }}
         uses: actions/checkout@v4
         with:
           ref: ${{ env.MAIN_BRANCH }}
           fetch-depth: 0
 
       - name: Create PR to main branch
-        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true
-          }}
+        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && inputs.automatic_mode }}
         run: |
           gh pr create \
           --base ${{ env.MAIN_BRANCH }} \
@@ -87,14 +85,13 @@ jobs:
           --body "This PR incorporates package(s) version and changelog update."
 
       - name: Merge PR to main branch
-        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true
-          }}
+        if: ${{ inputs.release_candidate != env.MAIN_BRANCH && inputs.automatic_mode }}
         run: |
           gh pr merge ${{ inputs.release_candidate }} \
           --merge --delete-branch
 
       - name: Create prerelease
-        if: ${{ fromJSON(inputs.automatic_mode) == true && fromJSON(inputs.prerelease) == true}}
+        if: ${{ inputs.automatic_mode && inputs.prerelease}}
         run: |
           gh release create ${{ steps.catkin_release.outputs.version }} \
           --target ${{ env.MAIN_BRANCH }} \
@@ -103,7 +100,7 @@ jobs:
           --prerelease
 
       - name: Create release
-        if: ${{ fromJSON(inputs.automatic_mode) == true && fromJSON(inputs.prerelease) == false}}
+        if: ${{ inputs.automatic_mode && !inputs.prerelease }}
         run: |
           gh release create ${{ steps.catkin_release.outputs.version }} \
           --target ${{ env.MAIN_BRANCH }} \
@@ -111,14 +108,14 @@ jobs:
           --generate-notes
 
       - name: Checkout to devel branch
-        if: ${{ env.DEVEL_BRANCH != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true }}
+        if: ${{ env.DEVEL_BRANCH != env.MAIN_BRANCH && inputs.automatic_mode }}
         uses: actions/checkout@v4
         with:
           ref: ${{ env.DEVEL_BRANCH }}
           fetch-depth: 0
 
       - name: Update devel branch
-        if: ${{ env.DEVEL_BRANCH != env.MAIN_BRANCH && fromJSON(inputs.automatic_mode) == true }}
+        if: ${{ env.DEVEL_BRANCH != env.MAIN_BRANCH && inputs.automatic_mode }}
         run: |
           git pull origin ${{ env.MAIN_BRANCH }}
           git push origin ${{ env.DEVEL_BRANCH }}


### PR DESCRIPTION
### Description

- Reusable workflow must be defined as separate job.
- Standardized input references from `github.event.inputs` to direct `inputs` syntax

### Requirements

- [x] Code style guidelines followed
- [x] Documentation updated

### Tests 🧪

- [x] Workflow: Release Candidate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Updates**
	- Enhanced GitHub Actions workflows for Docker image building and release processes.
	- Improved input parameter handling across multiple workflow files.
	- Restructured job dependencies and added new jobs for release and Docker image management.
	- Standardized input references from `github.event.inputs` to direct `inputs` syntax.
	- Introduced a new input parameter `branch_name` for enhanced flexibility in Docker image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->