### PR TITLE
Fix roboteq robot driver deinitialization

### DIFF
--- a/husarion_ugv_hardware_interfaces/src/robot_system/robot_driver/roboteq_robot_driver.cpp
+++ b/husarion_ugv_hardware_interfaces/src/robot_system/robot_driver/roboteq_robot_driver.cpp
@@ -70,6 +70,8 @@ void RoboteqRobotDriver::Initialize()
 
 void RoboteqRobotDriver::Deinitialize()
 {
+  drivers_.clear();
+  data_.clear();
   canopen_manager_.Deinitialize();
   initialized_ = false;
 }
@@ -250,7 +252,7 @@ void RoboteqRobotDriver::BootDrivers()
         throw std::runtime_error("Boot for " + name + " driver timed out or failed.");
       }
 
-    } catch (const std::system_error & e) {
+    } catch (const std::exception & e) {
       throw std::runtime_error(
         "An exception occurred while trying to Boot " + name + " driver " + std::string(e.what()));
     }


### PR DESCRIPTION
NOTE: This does not fix the issue with roboteq sometimes not being able to boot (happens only for rear driver), only fixes recovery so driver has few attempts to try Boot again 

### Description

- fix roboteq robot driver deinitialization

### Requirements

- [ ] Code style guidelines followed
- [ ] Documentation updated

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation
