### PR TITLE
Fix uint test workflow

### DIFF
--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -27,9 +27,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          use-ros2-testing: true
+      - name: Setup ROS
+        uses: ros-tooling/setup-ros@v0.7
 
       - name: Build and test
         uses: ros-tooling/action-ros-ci@v0.3


### PR DESCRIPTION
### Description

- ros2-testing installs pre-release packages which causes ros_components_description to fail. Installing release binaries fixes the issue. I guess in the upcomming version something has changed in kortex_description URDFs

### Requirements

- [ ] (Dependency PR)
- [ ] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the testing workflow by simplifying the ROS setup step and removing redundant configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->