### PR TITLE
Ros2 add use sim to components

### DIFF
--- a/husarion_ugv_description/urdf/lynx.urdf.xacro
+++ b/husarion_ugv_description/urdf/lynx.urdf.xacro
@@ -33,6 +33,7 @@
     <xacro:husarion_components.create_components
       components_config_path="${components_config_path_property}"
       namespace="$(arg namespace)"
+      use_sim="$(arg use_sim)"
     />
   </xacro:unless>
 </robot>

--- a/husarion_ugv_description/urdf/panther.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther.urdf.xacro
@@ -33,6 +33,7 @@
     <xacro:husarion_components.create_components
       components_config_path="${components_config_path_property}"
       namespace="$(arg namespace)"
+      use_sim="$(arg use_sim)"
     />
   </xacro:unless>
 </robot>


### PR DESCRIPTION
### Description

- added use_sim arg to components

### Requirements

- [ ] (Dependency PR)
- [x] Backport
- [x] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [x] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for simulation mode configuration in component creation for both Lynx and Panther robot descriptions. This allows components to be aware of and adjust for simulation mode when launching the robots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->