### PR TITLE
more worlds in gazebo

### DIFF
--- a/husarion_ugv/simulation_deps.repos
+++ b/husarion_ugv/simulation_deps.repos
@@ -10,7 +10,7 @@ repositories:
   husarion_gz_worlds:
     type: git
     url: https://github.com/husarion/husarion_gz_worlds.git
-    version: 97275568c34e6fe191ca34fa1c1c2b897faf9610
+    version: 3cc8018a49de082f5e4d3fa7afa4e30dda9307c6
   husarion_components_description:
     type: git
     url: https://github.com/husarion/husarion_components_description.git

--- a/husarion_ugv/simulation_deps.repos
+++ b/husarion_ugv/simulation_deps.repos
@@ -10,7 +10,7 @@ repositories:
   husarion_gz_worlds:
     type: git
     url: https://github.com/husarion/husarion_gz_worlds.git
-    version: 3cc8018a49de082f5e4d3fa7afa4e30dda9307c6
+    version: 56b5788a9584d3bc31ba85d36582ba965752c27e
   husarion_components_description:
     type: git
     url: https://github.com/husarion/husarion_components_description.git

--- a/husarion_ugv_gazebo/README.md
+++ b/husarion_ugv_gazebo/README.md
@@ -9,6 +9,24 @@ The package contains a launch file and source files used to run the robot simula
 - `simulate_multiple_robots.launch.py`: Similar to the above with logic allowing you to quickly add a swarm of robots.
 - **`simulation.launch.py`**: A target file that runs the gazebo simulator that adds and simulates the robot's behavior in accordance with the given arguments.
 
+### Worlds
+
+To run the simulation with a different world, use:
+
+```bash
+ros2 launch husarion_ugv_gazebo simulation.launch.py gz_world:=<world>
+```
+
+Where `<world>` is either a path to an SDF file or the name of a built-in world in `husarion_gz_worlds`. The default world is `husarion_world`.
+
+Available worlds:
+- `cave`
+- `empty_with_plugins`
+- `husarion_office`
+- `husarion_world`
+- `rubicon`
+- `sonoma_raceway`
+
 ## Configuration Files
 
 - [`battery_plugin.yaml`](./config/battery_plugin.yaml): Simulated LinearBatteryPlugin configuration.

--- a/husarion_ugv_gazebo/launch/spawn_robot.launch.py
+++ b/husarion_ugv_gazebo/launch/spawn_robot.launch.py
@@ -60,7 +60,7 @@ def generate_launch_description():
 
     y = LaunchConfiguration("y")
     declare_y_arg = DeclareLaunchArgument(
-        "y", default_value="-2.0", description="Initial robot position in the global 'y' axis."
+        "y", default_value="0.0", description="Initial robot position in the global 'y' axis."
     )
 
     z = LaunchConfiguration("z")


### PR DESCRIPTION
### Description

I have added a new `scene` launch argument in `husarion_ugv_gazebo`, in `simulation.launch.py`, which can be set to predefined strings like `outdoor`, `ioffice`, etc. This allows to easily switch between worlds.

Specifying the argument effectively updates the launch arguments passed to descendant launch files, `husarion_gz_worlds/gz_sim.launch.py`, and `husarion_ugv_gazebo/simulate_robot.launch.py`. This is done in order to load a different world and to set a more suitable initial position of the robot.

Try it out like this:

```bash
ros2 launch husarion_ugv_gazebo simulation.launch.py scene:=outdoor
```

Scenes to review:
- [ARG NOT SPECIFIED] - default Husarion world from `husarion_gz_worlds`
- `office` - Husarion office from `husarion_gz_worlds`
- `raceway` - modified [Sonoma Raceway](https://app.gazebosim.org/OpenRobotics/fuel/models/Sonoma%20Raceway) from `husarion_gz_worlds`
- `outdoor` - [Rubicon World from Gazebo Fuel @ Cole](https://app.gazebosim.org/Cole/fuel/worlds/Rubicon%20World)
- `cave` - [Cave World from Gazebo Fuel @ OpenRobotics](https://app.gazebosim.org/OpenRobotics/fuel/worlds/Cave%20World)

### Requirements

- [ ] Backport
- [x] Code style guidelines followed
- [x] Documentation updated

### Tests 🧪

- [ ] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Worlds" section to the README explaining how to run simulations with different world scenes and listing available built-in worlds.

* **Chores**
  * Updated the version of the simulation worlds dependency.

* **Refactor**
  * Changed the default initial robot position along the 'y' axis in the simulation launch settings from -2.0 to 0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->