### PR TITLE
fix soft e-stop logic

### DIFF
--- a/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/robot_system/system_e_stop.hpp
+++ b/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/robot_system/system_e_stop.hpp
@@ -113,6 +113,7 @@ protected:
 
   std::mutex e_stop_manipulation_mtx_;
   std::atomic_bool e_stop_triggered_ = true;
+  std::atomic_bool software_e_stop_triggered_ = true;
 };
 
 }  // namespace husarion_ugv_hardware_interfaces

--- a/husarion_ugv_hardware_interfaces/src/robot_system/gpio/gpio_controller.cpp
+++ b/husarion_ugv_hardware_interfaces/src/robot_system/gpio/gpio_controller.cpp
@@ -133,13 +133,14 @@ void GPIOController::EStopReset()
   const auto e_stop_pin = GPIOPin::E_STOP_RESET;
   bool e_stop_state = !gpio_driver_->IsPinActive(e_stop_pin);
 
+  watchdog_->TurnOn();
+
   if (!e_stop_state) {
     fprintf(stdout, "[GPIOController] E-stop is not active, reset is not needed\n");
     return;
   }
 
   gpio_driver_->ChangePinDirection(e_stop_pin, gpiod::line::direction::OUTPUT);
-  watchdog_->TurnOn();
   gpio_driver_->SetPinValue(e_stop_pin, true);
 
   if (!WaitFor(std::chrono::milliseconds(100))) {

--- a/husarion_ugv_hardware_interfaces/src/robot_system/system_e_stop.cpp
+++ b/husarion_ugv_hardware_interfaces/src/robot_system/system_e_stop.cpp
@@ -32,11 +32,12 @@ bool EStop::ReadEStopState()
     // Roboteq or Safety Board), disabling the software Watchdog is necessary to prevent an
     // uncontrolled reset.
     if (e_stop_triggered_) {
+      software_e_stop_triggered_ = true;
       gpio_controller_->EStopTrigger();
     }
   }
 
-  return e_stop_triggered_;
+  return e_stop_triggered_ || software_e_stop_triggered_;
 }
 
 void EStop::TriggerEStop()
@@ -45,6 +46,7 @@ void EStop::TriggerEStop()
 
   std::lock_guard<std::mutex> e_stop_lck(e_stop_manipulation_mtx_);
   try {
+    software_e_stop_triggered_ = true;
     gpio_controller_->EStopTrigger();
   } catch (const std::runtime_error & e) {
     throw std::runtime_error("Setting E-stop failed: " + std::string(e.what()));
@@ -79,6 +81,7 @@ void EStop::ResetEStop()
     roboteq_error_filter_->SetClearErrorsFlag();
 
     e_stop_triggered_ = false;
+    software_e_stop_triggered_ = false;
   } else {
     std::fprintf(stdout, "E-stop trigger operation is in progress, skipping reset.");
   }


### PR DESCRIPTION
### Description

- Fix software e-stop logic. This is relevant when internal EMU SW1-01 is set to OFF position

### Requirements

- [x] (Dependency PR)
- [x] Backport
- [x] Code style guidelines followed
- [x] Documentation updated
- [x] Other repositories updated `.repos`

### Tests 🧪

- [x] Robot
- [x] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking software-triggered emergency stop (E-stop) states, in addition to hardware-triggered E-stop states.

* **Bug Fixes**
  * Improved consistency in handling and resetting both hardware and software E-stop triggers.

* **Refactor**
  * Adjusted the sequence of operations for enabling the watchdog during E-stop reset for more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->