### PR TITLE
husarion_components_description refactor compatibility

### DIFF
--- a/husarion_ugv_description/CONFIGURATION.md
+++ b/husarion_ugv_description/CONFIGURATION.md
@@ -12,7 +12,7 @@ components:
     parent_link: cover_link
     xyz: 0.2 -0.2 0.0
     rpy: 0.0 0.0 0.0
-    device_namespace: ur5
+    name: ur5
 ```
 
 In this example:
@@ -20,7 +20,7 @@ In this example:
     - `parent_link`: cover_link: Defines the parent link to attach the component.
     - `xyz`: 0.2 -0.2 0.0: Sets the position of the component.
     - `rpy`: 0.0 0.0 0.0: Sets the rotation of the component.
-    - `device_namespace`: ur5: Sets the device namespace.
+    - `name`: ur5: Sets the component name.
 
 ### Visualize Robot Model Configuration
 
@@ -50,12 +50,12 @@ components:
     parent_link: cover_link
     xyz: 0.2 -0.2 0.0
     rpy: 0.0 0.0 0.0
-    device_namespace: left_ur5
+    name: left_ur5
   - type: MAN02
     parent_link: cover_link
     xyz: 0.2 0.2 0.0
     rpy: 0.0 0.0 0.0
-    device_namespace: right_ur5
+    name: right_ur5
 ```
 
 To use the `ros2 launch` command to launch the `overwrite_robot_description.launch.py` file with the appropriate arguments to overwrite the robot model, follow these steps:

--- a/husarion_ugv_gazebo/CONFIGURATION.md
+++ b/husarion_ugv_gazebo/CONFIGURATION.md
@@ -15,7 +15,7 @@ To obtain GPS data in Ignition, follow these steps:
     parent_link: cover_link
     xyz: 0.185 -0.12 0.0
     rpy: 0.0 0.0 3.14
-    device_namespace: gps
+    name: gps
 ```
 
 - Add the following tag to your world's SDF file and specify this file using the `world` parameter (the default `husarion_world.sdf` file already includes this tag):

--- a/husarion_ugv_localization/launch/nmea_navsat.launch.py
+++ b/husarion_ugv_localization/launch/nmea_navsat.launch.py
@@ -59,7 +59,7 @@ def generate_launch_description():
         namespace=namespace,
         parameters=[
             {
-                "frame_id": component_name,
+                "frame_id": component_name + "_antenna",
                 "tf_prefix": namespace,
             },
             nmea_params_path,

--- a/husarion_ugv_localization/launch/nmea_navsat.launch.py
+++ b/husarion_ugv_localization/launch/nmea_navsat.launch.py
@@ -51,7 +51,7 @@ def generate_launch_description():
         description="Namespace to all launched nodes and use namespace as tf_prefix. This aids in differentiating between multiple robots with the same devices.",
     )
 
-    device_namespace = "gps"
+    component_name = "gps"
     nmea_driver_node = Node(
         package="nmea_navsat_driver",
         executable="nmea_socket_driver",
@@ -59,16 +59,16 @@ def generate_launch_description():
         namespace=namespace,
         parameters=[
             {
-                "frame_id": device_namespace,
+                "frame_id": component_name,
                 "tf_prefix": namespace,
             },
             nmea_params_path,
         ],
         remappings=[
-            ("fix", [device_namespace, "/fix"]),
-            ("time_reference", [device_namespace, "/time_reference"]),
-            ("vel", [device_namespace, "/vel"]),
-            ("heading", ["_", device_namespace, "/heading"]),
+            ("fix", [component_name, "/fix"]),
+            ("time_reference", [component_name, "/time_reference"]),
+            ("vel", [component_name, "/vel"]),
+            ("heading", ["_", component_name, "/heading"]),
         ],
         arguments=[
             "--ros-args",


### PR DESCRIPTION
### Description

see https://github.com/husarion/husarion_components_description/pull/9

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [ ] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated configuration examples to use the field “name” instead of “device_namespace” across components.
  * Clarified descriptions to indicate the field sets the component name.
  * Refreshed GPS configuration example to align with the new field naming.

* Refactor
  * Standardized runtime naming: internal references now use component “name” for frame_id and topic remappings (e.g., gps_antenna and related topics), replacing previous device_namespace-based naming.
  * No functional parameter changes; only identifiers and remaps updated for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->