### PR TITLE
add ground truth odometry and tf

### DIFF
--- a/ROS_API.md
+++ b/ROS_API.md
@@ -1,16 +1,5 @@
 # ROS API
 
-> [!IMPORTANT]
-> **Beta Release**
->
-> Please be advised that the software you are about to use is a Beta version of the ROS 2 Driver for Lynx and Panther. It is functional, and the architecture will not change significantly. Although it has been tested by the Husarion team, some stability issues and bugs may still occur.
->
-> We would greatly appreciate your feedback regarding the Husarion UGV ROS 2 driver. You can reach us in the following ways:
->
-> - By email at: [support@husarion.com](mailto:support@husarion.com)
-> - Via our community forum: [Husarion Community](https://community.husarion.com)
-> - By submitting an issue request on: [GitHub](https://github.com/husarion/husarion_ugv_ros/issues)
-
 ## ROS 2 System Design
 
 This section describes the ROS packages used in Husarion UGV. These packages are located in the [husarion_ugv_ros](https://github.com/husarion/husarion_ugv_ros) GitHub repository.
@@ -87,20 +76,22 @@ Below is information about the physical robot API. For the simulation, topics an
 | ✅   | ✅   | `localization/set_pose`       | Sets the pose of the EKF node.<br/> [*geometry_msgs/PoseWithCovarianceStamped*](https://docs.ros2.org/latest/api/geometry_msgs/msg/PoseWithCovarianceStamped.html)                                                                                                                                                                                                        |
 | ✅   | ✅   | `manual/cmd_vel`              | Command velocity value for manual inputs.<br/> [*geometry_msgs/TwistStamped*](https://docs.ros2.org/latest/api/geometry_msgs/msg/TwistStamped.html)                                                                                                                                                                                                                                                       |
 | ✅   | ✅   | `odometry/filtered`           | Contains information about the filtered position and orientation. When `localization_mode` is `relative`, the position and orientation are relative to the starting point. When `localization_mode` is `enu`, the orientation is relative to the east-north-up (ENU) coordinates.<br/> [*nav_msgs/Odometry*](https://docs.ros2.org/latest/api/nav_msgs/msg/Odometry.html) |
+| ❌   | ✅   | `odometry/ground_truth`       | Robot odometry with ground truth values.<br/> [*nav_msgs/Odometry*](https://docs.ros2.org/latest/api/nav_msgs/msg/Odometry.html)                                                                                                                                                                                                                                            |
 | ✅   | ✅   | `odometry/wheels`             | Robot odometry calculated from wheels.<br/> [*nav_msgs/Odometry*](https://docs.ros2.org/latest/api/nav_msgs/msg/Odometry.html)                                                                                                                                                                                                                                            |
 | ✅   | ✅   | `robot_description`           | Contains information about robot description from URDF file. <br/> [*std_msgs/String*](https://docs.ros2.org/latest/api/std_msgs/msg/String.html)                                                                                                                                                                                                                         |
 | ✅   | ❌   | `system_status`               | State of the system, including Built-in Computer's CPU temperature and load. <br/> [*husarion_ugv_msgs/SystemStatus*](husarion_ugv_msgs/msg/SystemStatus.msg)                                                                                                                                                                                                                |
 | ✅   | ✅   | `tf`                          | Transforms of robot system.<br/> [*tf2_msgs/TFMessage*](https://docs.ros2.org/latest/api/tf2_msgs/msg/TFMessage.html)                                                                                                                                                                                                                                                     |
+| ❌   | ✅   | `tf_gt`                       | Ground truth transform of robot system. Provides transform from `world` to `base_link` frame.<br/> [*tf2_msgs/TFMessage*](https://docs.ros2.org/latest/api/tf2_msgs/msg/TFMessage.html)                                                                                                                                                                                                                                                     |
 | ✅   | ✅   | `tf_static`                   | Static transforms of robot system.<br/> [*tf2_msgs/TFMessage*](https://docs.ros2.org/latest/api/tf2_msgs/msg/TFMessage.html)                                                                                                                                                                                                                                              |
 
 #### Hidden topics
 
 | 🤖   | 🖥️   | Topic                           | Description                                                                                                                                                            |
 | --- | --- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅   | ❌   | `_battery/battery_1_status_raw` | First battery raw state. <br/> [_sensor_msgs/BatteryState_](https://docs.ros2.org/latest/api/sensor_msgs/msg/BatteryState.html)                                        |
-| ✅   | ❌   | `_battery/battery_2_status_raw` | Second battery raw state. Published if second battery detected. <br/> [_sensor_msgs/BatteryState_](https://docs.ros2.org/latest/api/sensor_msgs/msg/BatteryState.html) |
-| ✅   | ❌   | `_gps/heading`                  | Not supported for current configuration. <br/> [_geometry_msgs/QuaternionStamped_](https://docs.ros2.org/latest/api/geometry_msgs/msg/QuaternionStamped.html)          |
-| ✅   | ✅   | ⚙️ `_odometry/gps` ⚙️             | Transformed raw GPS data to odometry format. <br/> [_nav_msgs/Odometry_](https://docs.ros2.org/latest/api/nav_msgs/msg/Odometry.html)                                  |
+| ✅   | ❌   | `_battery/battery_1_status_raw` | First battery raw state. <br/> [*sensor_msgs/BatteryState*](https://docs.ros2.org/latest/api/sensor_msgs/msg/BatteryState.html)                                        |
+| ✅   | ❌   | `_battery/battery_2_status_raw` | Second battery raw state. Published if second battery detected. <br/> [*sensor_msgs/BatteryState*](https://docs.ros2.org/latest/api/sensor_msgs/msg/BatteryState.html) |
+| ✅   | ❌   | `_gps/heading`                  | Not supported for current configuration. <br/> [*geometry_msgs/QuaternionStamped*](https://docs.ros2.org/latest/api/geometry_msgs/msg/QuaternionStamped.html)          |
+| ✅   | ✅   | ⚙️ `_odometry/gps` ⚙️             | Transformed raw GPS data to odometry format. <br/> [*nav_msgs/Odometry*](https://docs.ros2.org/latest/api/nav_msgs/msg/Odometry.html)                                  |
 
 ### Services
 

--- a/husarion_ugv_description/urdf/common/gazebo.urdf.xacro
+++ b/husarion_ugv_description/urdf/common/gazebo.urdf.xacro
@@ -142,4 +142,22 @@
     </gazebo>
   </xacro:macro>
 
+  <xacro:macro name="odometry_publisher" params="namespace:=''">
+
+    <xacro:property name="ns" value='${namespace + "/" if namespace else ""}' />
+
+    <gazebo>
+      <plugin
+        filename="gz-sim-odometry-publisher-system"
+        name="gz::sim::systems::OdometryPublisher">
+        <odom_frame>world</odom_frame>
+        <robot_base_frame>${ns}base_link</robot_base_frame>
+        <odom_topic>${ns}odometry/ground_truth</odom_topic>
+        <odom_covariance_topic>${ns}odometry/ground_truth_covariance</odom_covariance_topic>
+        <tf_topic>tf_gt</tf_topic>
+        <odom_publish_frequency>50.0</odom_publish_frequency>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+
 </robot>

--- a/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
@@ -189,6 +189,7 @@
       <xacro:gazebo.imu reference_frame="imu_link" namespace="${namespace}" />
       <xacro:gazebo.light reference_frame="lights_channel_1_link" name="lights_channel_1" topic="lights/channel_1_frame" namespace="${namespace}" />
       <xacro:gazebo.light reference_frame="lights_channel_2_link" name="lights_channel_2" topic="lights/channel_2_frame" namespace="${namespace}" />
+      <xacro:gazebo.odometry_publisher namespace="${namespace}" />
     </xacro:if>
   </xacro:macro>
 

--- a/husarion_ugv_gazebo/config/robot_bridge.yaml
+++ b/husarion_ugv_gazebo/config/robot_bridge.yaml
@@ -31,3 +31,13 @@
   ros_type_name: sensor_msgs/msg/Image
   gz_type_name: gz.msgs.Image
   direction: ROS_TO_GZ
+
+- topic_name: /tf_gt
+  ros_type_name: tf2_msgs/msg/TFMessage
+  gz_type_name: gz.msgs.Pose_V
+  direction: GZ_TO_ROS
+
+- topic_name: /<namespace>/odometry/ground_truth
+  ros_type_name: nav_msgs/msg/Odometry
+  gz_type_name: gz.msgs.Odometry
+  direction: GZ_TO_ROS


### PR DESCRIPTION
### Description

https://github.com/husarion/elrob2026/issues/80

- Add gazebo odometry publisher which allows to publish ground truth when working with simulation
- Remove beta release note

### Requirements

- [x] (Dependency PR)
- [x] Backport
- [x] Code style guidelines followed
- [x] Documentation updated
- [x] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [x] Simulation
