### PR TITLE
Standard bt plugins support

### DIFF
--- a/husarion_ugv_manager/CMakeLists.txt
+++ b/husarion_ugv_manager/CMakeLists.txt
@@ -315,6 +315,7 @@ if(BUILD_TESTING)
                         safety_manager_parameters OpenSSL::SSL)
 endif()
 
+ament_export_libraries(${plugin_libs})
 ament_export_dependencies(${PACKAGE_DEPENDENCIES})
 ament_export_include_directories(include/${PROJECT_NAME})
 

--- a/husarion_ugv_manager/include/husarion_ugv_manager/behavior_tree_utils.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/behavior_tree_utils.hpp
@@ -101,6 +101,10 @@ inline BT::RosNodeParams CreateRosNodeParamsFromBlackboard(const BT::NodeConfig 
     throw BT::RuntimeError("Failed to get rclcpp::Node from blackboard: ", e.what());
   }
 
+  if (!node) {
+    throw BT::RuntimeError("rclcpp::Node is nullptr");
+  }
+
   return BT::RosNodeParams(node);
 }
 

--- a/husarion_ugv_manager/include/husarion_ugv_manager/behavior_tree_utils.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/behavior_tree_utils.hpp
@@ -77,6 +77,33 @@ inline void RegisterBehaviorTree(
   RegisterBehaviorTree(factory, bt_project_path, plugin_libs);
 }
 
+/**
+ * @brief Creates RosNodeParams from the blackboard contained in the NodeConfig.
+ *
+ * @param conf The NodeConfig containing the blackboard.
+ * @return BT::RosNodeParams The created RosNodeParams.
+ *
+ * @throw std::runtime_error Throws when the blackboard is nullptr or the node
+ * (rclcpp::Node::SharedPtr) is not found or is nullptr.
+ */
+inline BT::RosNodeParams CreateRosNodeParamsFromBlackboard(const BT::NodeConfig & conf)
+{
+  auto blackboard = conf.blackboard;
+  if (!blackboard) {
+    throw std::runtime_error("Blackboard is nullptr");
+  }
+
+  rclcpp::Node::SharedPtr node;
+
+  try {
+    node = blackboard->get<rclcpp::Node::SharedPtr>("node");
+  } catch (const std::exception & e) {
+    throw BT::RuntimeError("Failed to get rclcpp::Node from blackboard: ", e.what());
+  }
+
+  return BT::RosNodeParams(node);
+}
+
 }  // namespace husarion_ugv_manager::behavior_tree_utils
 
 namespace husarion_ugv_manager

--- a/husarion_ugv_manager/include/husarion_ugv_manager/plugins/action/call_set_bool_service_node.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/plugins/action/call_set_bool_service_node.hpp
@@ -22,12 +22,20 @@
 
 #include "std_srvs/srv/set_bool.hpp"
 
+#include "husarion_ugv_manager/behavior_tree_utils.hpp"
+
 namespace husarion_ugv_manager
 {
 
 class CallSetBoolService : public BT::RosServiceNode<std_srvs::srv::SetBool>
 {
 public:
+  CallSetBoolService(const std::string & name, const BT::NodeConfig & conf)
+  : BT::RosServiceNode<std_srvs::srv::SetBool>(
+      name, conf, behavior_tree_utils::CreateRosNodeParamsFromBlackboard(conf))
+  {
+  }
+
   CallSetBoolService(
     const std::string & name, const BT::NodeConfig & conf, const BT::RosNodeParams & params)
   : BT::RosServiceNode<std_srvs::srv::SetBool>(name, conf, params)

--- a/husarion_ugv_manager/include/husarion_ugv_manager/plugins/action/call_set_led_animation_service_node.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/plugins/action/call_set_led_animation_service_node.hpp
@@ -22,6 +22,8 @@
 
 #include "husarion_ugv_msgs/srv/set_led_animation.hpp"
 
+#include "husarion_ugv_manager/behavior_tree_utils.hpp"
+
 namespace husarion_ugv_manager
 {
 
@@ -29,6 +31,12 @@ class CallSetLedAnimationService
 : public BT::RosServiceNode<husarion_ugv_msgs::srv::SetLEDAnimation>
 {
 public:
+  CallSetLedAnimationService(const std::string & name, const BT::NodeConfig & conf)
+  : BT::RosServiceNode<husarion_ugv_msgs::srv::SetLEDAnimation>(
+      name, conf, behavior_tree_utils::CreateRosNodeParamsFromBlackboard(conf))
+  {
+  }
+
   CallSetLedAnimationService(
     const std::string & name, const BT::NodeConfig & conf, const BT::RosNodeParams & params)
   : BT::RosServiceNode<husarion_ugv_msgs::srv::SetLEDAnimation>(name, conf, params)

--- a/husarion_ugv_manager/include/husarion_ugv_manager/plugins/action/call_trigger_service_node.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/plugins/action/call_trigger_service_node.hpp
@@ -22,12 +22,20 @@
 
 #include "std_srvs/srv/trigger.hpp"
 
+#include "husarion_ugv_manager/behavior_tree_utils.hpp"
+
 namespace husarion_ugv_manager
 {
 
 class CallTriggerService : public BT::RosServiceNode<std_srvs::srv::Trigger>
 {
 public:
+  CallTriggerService(const std::string & name, const BT::NodeConfig & conf)
+  : BT::RosServiceNode<std_srvs::srv::Trigger>(
+      name, conf, behavior_tree_utils::CreateRosNodeParamsFromBlackboard(conf))
+  {
+  }
+
   CallTriggerService(
     const std::string & name, const BT::NodeConfig & conf, const BT::RosNodeParams & params)
   : BT::RosServiceNode<std_srvs::srv::Trigger>(name, conf, params)

--- a/husarion_ugv_manager/include/husarion_ugv_manager/plugins/condition/check_bool_msg.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/plugins/condition/check_bool_msg.hpp
@@ -35,6 +35,12 @@ class CheckBoolMsg : public BT::RosTopicSubNode<std_msgs::msg::Bool>
   using BoolMsg = std_msgs::msg::Bool;
 
 public:
+  CheckBoolMsg(const std::string & name, const BT::NodeConfig & conf)
+  : BT::RosTopicSubNode<BoolMsg>(
+      name, conf, behavior_tree_utils::CreateRosNodeParamsFromBlackboard(conf))
+  {
+  }
+
   CheckBoolMsg(
     const std::string & name, const BT::NodeConfig & conf, const BT::RosNodeParams & params)
   : BT::RosTopicSubNode<BoolMsg>(name, conf, params)

--- a/husarion_ugv_manager/include/husarion_ugv_manager/plugins/condition/check_joy_msg.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/plugins/condition/check_joy_msg.hpp
@@ -34,6 +34,12 @@ class CheckJoyMsg : public BT::RosTopicSubNode<sensor_msgs::msg::Joy>
   using JoyMsg = sensor_msgs::msg::Joy;
 
 public:
+  CheckJoyMsg(const std::string & name, const BT::NodeConfig & conf)
+  : BT::RosTopicSubNode<JoyMsg>(
+      name, conf, behavior_tree_utils::CreateRosNodeParamsFromBlackboard(conf))
+  {
+  }
+
   CheckJoyMsg(
     const std::string & name, const BT::NodeConfig & conf, const BT::RosNodeParams & params)
   : BT::RosTopicSubNode<JoyMsg>(name, conf, params)

--- a/husarion_ugv_manager/include/husarion_ugv_manager/plugins/condition/check_string_msg.hpp
+++ b/husarion_ugv_manager/include/husarion_ugv_manager/plugins/condition/check_string_msg.hpp
@@ -34,6 +34,12 @@ class CheckStringMsg : public BT::RosTopicSubNode<std_msgs::msg::String>
   using StringMsg = std_msgs::msg::String;
 
 public:
+  CheckStringMsg(const std::string & name, const BT::NodeConfig & conf)
+  : BT::RosTopicSubNode<StringMsg>(
+      name, conf, behavior_tree_utils::CreateRosNodeParamsFromBlackboard(conf))
+  {
+  }
+
   CheckStringMsg(
     const std::string & name, const BT::NodeConfig & conf, const BT::RosNodeParams & params)
   : BT::RosTopicSubNode<StringMsg>(name, conf, params)

--- a/husarion_ugv_manager/src/lights_manager_node.cpp
+++ b/husarion_ugv_manager/src/lights_manager_node.cpp
@@ -143,6 +143,8 @@ std::map<std::string, std::any> LightsManagerNode::CreateLightsInitialBlackboard
     {"GOAL_ACHIEVED_ANIM_ID", unsigned(LEDAnimationMsg::GOAL_ACHIEVED)},
     {"BLINKER_LEFT_ANIM_ID", unsigned(LEDAnimationMsg::BLINKER_LEFT)},
     {"BLINKER_RIGHT_ANIM_ID", unsigned(LEDAnimationMsg::BLINKER_RIGHT)},
+    {"GOAL_FAILED_ANIM_ID", unsigned(LEDAnimationMsg::GOAL_FAILED)},
+    {"FLOOD_LIGHT_ANIM_ID", unsigned(LEDAnimationMsg::FLOOD_LIGHT)},
     // battery status constants
     {"POWER_SUPPLY_STATUS_UNKNOWN", unsigned(BatteryStateMsg::POWER_SUPPLY_STATUS_UNKNOWN)},
     {"POWER_SUPPLY_STATUS_CHARGING", unsigned(BatteryStateMsg::POWER_SUPPLY_STATUS_CHARGING)},

--- a/husarion_ugv_manager/src/plugins/action/call_set_bool_service_node.cpp
+++ b/husarion_ugv_manager/src/plugins/action/call_set_bool_service_node.cpp
@@ -46,3 +46,9 @@ BT::NodeStatus CallSetBoolService::onResponseReceived(const typename Response::S
 
 #include "behaviortree_ros2/plugins.hpp"
 CreateRosNodePlugin(husarion_ugv_manager::CallSetBoolService, "CallSetBoolService");
+
+#include "behaviortree_cpp/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<husarion_ugv_manager::CallSetBoolService>("CallSetBoolService");
+}

--- a/husarion_ugv_manager/src/plugins/action/call_set_led_animation_service_node.cpp
+++ b/husarion_ugv_manager/src/plugins/action/call_set_led_animation_service_node.cpp
@@ -66,3 +66,10 @@ BT::NodeStatus CallSetLedAnimationService::onResponseReceived(
 
 #include "behaviortree_ros2/plugins.hpp"
 CreateRosNodePlugin(husarion_ugv_manager::CallSetLedAnimationService, "CallSetLedAnimationService");
+
+#include "behaviortree_cpp/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<husarion_ugv_manager::CallSetLedAnimationService>(
+    "CallSetLedAnimationService");
+}

--- a/husarion_ugv_manager/src/plugins/action/call_trigger_service_node.cpp
+++ b/husarion_ugv_manager/src/plugins/action/call_trigger_service_node.cpp
@@ -41,3 +41,9 @@ BT::NodeStatus CallTriggerService::onResponseReceived(const typename Response::S
 
 #include "behaviortree_ros2/plugins.hpp"
 CreateRosNodePlugin(husarion_ugv_manager::CallTriggerService, "CallTriggerService");
+
+#include "behaviortree_cpp/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<husarion_ugv_manager::CallTriggerService>("CallTriggerService");
+}

--- a/husarion_ugv_manager/src/plugins/condition/check_bool_msg.cpp
+++ b/husarion_ugv_manager/src/plugins/condition/check_bool_msg.cpp
@@ -32,3 +32,9 @@ BT::NodeStatus CheckBoolMsg::onTick(const BoolMsg::SharedPtr & last_msg)
 
 #include "behaviortree_ros2/plugins.hpp"
 CreateRosNodePlugin(husarion_ugv_manager::CheckBoolMsg, "CheckBoolMsg");
+
+#include "behaviortree_cpp/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<husarion_ugv_manager::CheckBoolMsg>("CheckBoolMsg");
+}

--- a/husarion_ugv_manager/src/plugins/condition/check_joy_msg.cpp
+++ b/husarion_ugv_manager/src/plugins/condition/check_joy_msg.cpp
@@ -90,3 +90,9 @@ bool CheckJoyMsg::checkTimeout(const JoyMsg::SharedPtr & last_msg)
 
 #include "behaviortree_ros2/plugins.hpp"
 CreateRosNodePlugin(husarion_ugv_manager::CheckJoyMsg, "CheckJoyMsg");
+
+#include "behaviortree_cpp/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<husarion_ugv_manager::CheckJoyMsg>("CheckJoyMsg");
+}

--- a/husarion_ugv_manager/src/plugins/condition/check_string_msg.cpp
+++ b/husarion_ugv_manager/src/plugins/condition/check_string_msg.cpp
@@ -40,3 +40,9 @@ bool CheckStringMsg::latchLastMessage() const { return true; }
 
 #include "behaviortree_ros2/plugins.hpp"
 CreateRosNodePlugin(husarion_ugv_manager::CheckStringMsg, "CheckStringMsg");
+
+#include "behaviortree_cpp/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<husarion_ugv_manager::CheckStringMsg>("CheckStringMsg");
+}

--- a/husarion_ugv_manager/test/plugins/action/test_call_set_bool_service_node.cpp
+++ b/husarion_ugv_manager/test/plugins/action/test_call_set_bool_service_node.cpp
@@ -43,13 +43,25 @@ void TestCallSetBoolService::ServiceCallback(
     rclcpp::get_logger("test_set_bool_plugin"), response->message << " data: " << request->data);
 }
 
-TEST_F(TestCallSetBoolService, GoodLoadingCallSetBoolServicePlugin)
+TEST_F(TestCallSetBoolService, GoodLoadingCallSetBoolServiceRosPlugin)
 {
   std::map<std::string, std::string> service = {{"service_name", "set_bool"}, {"data", "true"}};
 
   RegisterNodeWithParams<husarion_ugv_manager::CallSetBoolService>("CallSetBoolService");
 
   ASSERT_NO_THROW({ CreateTree("CallSetBoolService", service); });
+}
+
+TEST_F(TestCallSetBoolService, GoodLoadingCallSetBoolServicePlugin)
+{
+  std::map<std::string, std::string> service = {{"service_name", "set_bool"}, {"data", "true"}};
+
+  RegisterNodeWithoutParams<husarion_ugv_manager::CallSetBoolService>("CallSetBoolService");
+
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set<rclcpp::Node::SharedPtr>("node", this->bt_node_);
+
+  ASSERT_NO_THROW({ CreateTree("CallSetBoolService", service, blackboard); });
 }
 
 TEST_F(TestCallSetBoolService, WrongPluginNameLoadingCallSetBoolServicePlugin)

--- a/husarion_ugv_manager/test/plugins/action/test_call_set_led_animation_service_node.cpp
+++ b/husarion_ugv_manager/test/plugins/action/test_call_set_led_animation_service_node.cpp
@@ -50,7 +50,7 @@ void TestCallSetLedAnimationService::ServiceCallback(
   EXPECT_EQ(request->repeating, repeating);
 }
 
-TEST_F(TestCallSetLedAnimationService, GoodLoadingCallSetLedAnimationServicePlugin)
+TEST_F(TestCallSetLedAnimationService, GoodLoadingCallSetLedAnimationServiceRosPlugin)
 {
   std::map<std::string, std::string> service = {
     {"service_name", "set_led_animation"}, {"id", "0"}, {"param", ""}, {"repeating", "true"}};
@@ -59,6 +59,20 @@ TEST_F(TestCallSetLedAnimationService, GoodLoadingCallSetLedAnimationServicePlug
     "CallSetLedAnimationService");
 
   ASSERT_NO_THROW({ CreateTree("CallSetLedAnimationService", service); });
+}
+
+TEST_F(TestCallSetLedAnimationService, GoodLoadingCallSetLedAnimationServicePlugin)
+{
+  std::map<std::string, std::string> service = {
+    {"service_name", "set_led_animation"}, {"id", "0"}, {"param", ""}, {"repeating", "true"}};
+
+  RegisterNodeWithoutParams<husarion_ugv_manager::CallSetLedAnimationService>(
+    "CallSetLedAnimationService");
+
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set<rclcpp::Node::SharedPtr>("node", this->bt_node_);
+
+  ASSERT_NO_THROW({ CreateTree("CallSetLedAnimationService", service, blackboard); });
 }
 
 TEST_F(TestCallSetLedAnimationService, WrongPluginNameLoadingCallSetLedAnimationServicePlugin)

--- a/husarion_ugv_manager/test/plugins/action/test_call_trigger_service_node.cpp
+++ b/husarion_ugv_manager/test/plugins/action/test_call_trigger_service_node.cpp
@@ -41,13 +41,25 @@ void TestCallTriggerService::ServiceCallback(
   RCLCPP_INFO_STREAM(rclcpp::get_logger("test_trigger_plugin"), response->message);
 }
 
-TEST_F(TestCallTriggerService, GoodLoadingCallTriggerServicePlugin)
+TEST_F(TestCallTriggerService, GoodLoadingCallTriggerServiceRosPlugin)
 {
   std::map<std::string, std::string> service = {{"service_name", "trigger"}};
 
   RegisterNodeWithParams<husarion_ugv_manager::CallTriggerService>("CallTriggerService");
 
   ASSERT_NO_THROW({ CreateTree("CallTriggerService", service); });
+}
+
+TEST_F(TestCallTriggerService, GoodLoadingCallTriggerServicePlugin)
+{
+  std::map<std::string, std::string> service = {{"service_name", "trigger"}};
+
+  RegisterNodeWithoutParams<husarion_ugv_manager::CallTriggerService>("CallTriggerService");
+
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set<rclcpp::Node::SharedPtr>("node", this->bt_node_);
+
+  ASSERT_NO_THROW({ CreateTree("CallTriggerService", service, blackboard); });
 }
 
 TEST_F(TestCallTriggerService, WrongPluginNameLoadingCallTriggerServicePlugin)

--- a/husarion_ugv_manager/test/plugins/condition/test_check_bool_msg.cpp
+++ b/husarion_ugv_manager/test/plugins/condition/test_check_bool_msg.cpp
@@ -44,7 +44,9 @@ constexpr auto PLUGIN = "CheckBoolMsg";
 class TestCheckBoolMsg : public husarion_ugv_manager::plugin_test_utils::PluginTestUtils
 {
 public:
-  TestCheckBoolMsg();
+  TestCheckBoolMsg() {}
+
+  void Initialize();
   BoolMsg CreateMsg(bool data);
   void PublishMsg(BoolMsg msg) { publisher_->publish(msg); }
 
@@ -52,7 +54,7 @@ protected:
   rclcpp::Publisher<BoolMsg>::SharedPtr publisher_;
 };
 
-TestCheckBoolMsg::TestCheckBoolMsg()
+void TestCheckBoolMsg::Initialize()
 {
   RegisterNodeWithParams<husarion_ugv_manager::CheckBoolMsg>(PLUGIN);
   publisher_ = bt_node_->create_publisher<BoolMsg>(TOPIC, 10);
@@ -65,8 +67,27 @@ BoolMsg TestCheckBoolMsg::CreateMsg(bool data)
   return msg;
 }
 
+TEST_F(TestCheckBoolMsg, GoodLoadingCheckBoolMsgRosPlugin)
+{
+  this->Initialize();
+  bt_ports input = {{"topic_name", TOPIC}, {"data", "true"}};
+  ASSERT_NO_THROW({ CreateTree(PLUGIN, input); });
+}
+
+TEST_F(TestCheckBoolMsg, GoodLoadingCheckBoolMsgPlugin)
+{
+  bt_ports input = {{"topic_name", TOPIC}, {"data", "true"}};
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set<rclcpp::Node::SharedPtr>("node", this->bt_node_);
+
+  RegisterNodeWithoutParams<husarion_ugv_manager::CheckBoolMsg>(PLUGIN);
+
+  ASSERT_NO_THROW({ CreateTree(PLUGIN, input, blackboard); });
+}
+
 TEST_F(TestCheckBoolMsg, NoMessageArrived)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"data", "true"}};
   ASSERT_NO_THROW({ CreateTree(PLUGIN, input); });
 
@@ -77,6 +98,7 @@ TEST_F(TestCheckBoolMsg, NoMessageArrived)
 
 TEST_F(TestCheckBoolMsg, OnTickBehavior)
 {
+  this->Initialize();
   std::vector<TestCase> test_cases = {
     {BT::NodeStatus::SUCCESS, {{"topic_name", TOPIC}, {"data", "true"}}, CreateMsg(true)},
     {BT::NodeStatus::SUCCESS, {{"topic_name", TOPIC}, {"data", "false"}}, CreateMsg(false)},

--- a/husarion_ugv_manager/test/plugins/condition/test_check_joy_msg.cpp
+++ b/husarion_ugv_manager/test/plugins/condition/test_check_joy_msg.cpp
@@ -46,7 +46,9 @@ constexpr auto PLUGIN = "CheckJoyMsg";
 class TestCheckJoyMsg : public husarion_ugv_manager::plugin_test_utils::PluginTestUtils
 {
 public:
-  TestCheckJoyMsg();
+  TestCheckJoyMsg() {}
+
+  void Initialize();
   void PublishMsg(JoyMsg msg) { joy_publisher_->publish(msg); };
   JoyMsg CreateMsg(
     const std::vector<float> & axes = {}, const std::vector<int> & buttons = {},
@@ -57,7 +59,7 @@ protected:
   rclcpp::Publisher<JoyMsg>::SharedPtr joy_publisher_;
 };
 
-TestCheckJoyMsg::TestCheckJoyMsg()
+void TestCheckJoyMsg::Initialize()
 {
   RegisterNodeWithParams<husarion_ugv_manager::CheckJoyMsg>(PLUGIN);
   joy_publisher_ = bt_node_->create_publisher<JoyMsg>(TOPIC, 10);
@@ -75,8 +77,27 @@ JoyMsg TestCheckJoyMsg::CreateMsg(
 
 void TestCheckJoyMsg::SetCurrentMsgTime(JoyMsg & msg) { msg.header.stamp = bt_node_->now(); }
 
+TEST_F(TestCheckJoyMsg, GoodLoadingCheckJoyMsgRosPlugin)
+{
+  this->Initialize();
+  bt_ports input = {{"topic_name", TOPIC}};
+  ASSERT_NO_THROW({ CreateTree(PLUGIN, input); });
+}
+
+TEST_F(TestCheckJoyMsg, GoodLoadingCheckJoyMsgPlugin)
+{
+  bt_ports input = {{"topic_name", TOPIC}};
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set<rclcpp::Node::SharedPtr>("node", this->bt_node_);
+
+  RegisterNodeWithoutParams<husarion_ugv_manager::CheckJoyMsg>(PLUGIN);
+
+  ASSERT_NO_THROW({ CreateTree(PLUGIN, input, blackboard); });
+}
+
 TEST_F(TestCheckJoyMsg, NoMessageArrived)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"axes", "0;0"}, {"buttons", "0;0"}, {"timeout", "1.0"}};
   ASSERT_NO_THROW({ CreateTree(PLUGIN, input); });
 
@@ -87,6 +108,7 @@ TEST_F(TestCheckJoyMsg, NoMessageArrived)
 
 TEST_F(TestCheckJoyMsg, TimeoutTests)
 {
+  this->Initialize();
   std::vector<TestCase> test_cases = {
     {BT::NodeStatus::SUCCESS,
      {{"topic_name", TOPIC}, {"axes", ""}, {"buttons", ""}, {"timeout", "0.5"}},
@@ -117,6 +139,7 @@ TEST_F(TestCheckJoyMsg, TimeoutTests)
 
 TEST_F(TestCheckJoyMsg, OnTickBehavior)
 {
+  this->Initialize();
   std::vector<TestCase> test_cases = {
     {BT::NodeStatus::SUCCESS,
      {{"topic_name", TOPIC}, {"axes", ""}, {"buttons", ""}, {"timeout", "1.0"}},

--- a/husarion_ugv_manager/test/plugins/condition/test_check_string_msg.cpp
+++ b/husarion_ugv_manager/test/plugins/condition/test_check_string_msg.cpp
@@ -44,7 +44,9 @@ constexpr auto PLUGIN = "CheckStringMsg";
 class TestCheckStringMsg : public husarion_ugv_manager::plugin_test_utils::PluginTestUtils
 {
 public:
-  TestCheckStringMsg();
+  TestCheckStringMsg() {}
+
+  void Initialize();
   StringMsg CreateMsg(const std::string & data);
   void PublishMsg(StringMsg msg) { publisher_->publish(msg); }
 
@@ -52,7 +54,7 @@ protected:
   rclcpp::Publisher<StringMsg>::SharedPtr publisher_;
 };
 
-TestCheckStringMsg::TestCheckStringMsg()
+void TestCheckStringMsg::Initialize()
 {
   RegisterNodeWithParams<husarion_ugv_manager::CheckStringMsg>(PLUGIN);
   publisher_ = bt_node_->create_publisher<StringMsg>(TOPIC, 10);
@@ -65,8 +67,27 @@ StringMsg TestCheckStringMsg::CreateMsg(const std::string & data)
   return msg;
 }
 
+TEST_F(TestCheckStringMsg, GoodLoadingCheckStringMsgRosPlugin)
+{
+  this->Initialize();
+  bt_ports input = {{"topic_name", TOPIC}, {"data", "true"}};
+  ASSERT_NO_THROW({ CreateTree(PLUGIN, input); });
+}
+
+TEST_F(TestCheckStringMsg, GoodLoadingCheckStringMsgPlugin)
+{
+  bt_ports input = {{"topic_name", TOPIC}, {"data", "true"}};
+  auto blackboard = BT::Blackboard::create();
+  blackboard->set<rclcpp::Node::SharedPtr>("node", this->bt_node_);
+
+  RegisterNodeWithoutParams<husarion_ugv_manager::CheckStringMsg>(PLUGIN);
+
+  ASSERT_NO_THROW({ CreateTree(PLUGIN, input, blackboard); });
+}
+
 TEST_F(TestCheckStringMsg, NoInputData)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}};
   ASSERT_NO_THROW({ CreateTree(PLUGIN, input); });
 
@@ -82,6 +103,7 @@ TEST_F(TestCheckStringMsg, NoInputData)
 
 TEST_F(TestCheckStringMsg, NoMessageArrived)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"data", "name"}};
   ASSERT_NO_THROW({ CreateTree(PLUGIN, input); });
 
@@ -92,6 +114,7 @@ TEST_F(TestCheckStringMsg, NoMessageArrived)
 
 TEST_F(TestCheckStringMsg, SuccessOnExactMatch)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"data", "name"}};
   CreateTree(PLUGIN, input);
   auto & tree = GetTree();
@@ -105,6 +128,7 @@ TEST_F(TestCheckStringMsg, SuccessOnExactMatch)
 
 TEST_F(TestCheckStringMsg, SuccessOnMatchWithSpaces)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"data", "name with spaces"}};
   CreateTree(PLUGIN, input);
   auto & tree = GetTree();
@@ -118,6 +142,7 @@ TEST_F(TestCheckStringMsg, SuccessOnMatchWithSpaces)
 
 TEST_F(TestCheckStringMsg, SuccessOnMatchWithDots)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"data", "name.with.dots"}};
   CreateTree(PLUGIN, input);
   auto & tree = GetTree();
@@ -131,6 +156,7 @@ TEST_F(TestCheckStringMsg, SuccessOnMatchWithDots)
 
 TEST_F(TestCheckStringMsg, SuccessOnMatchWithMixedLetters)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"data", "MiXeDlEtTeRs"}};
   CreateTree(PLUGIN, input);
   auto & tree = GetTree();
@@ -144,6 +170,7 @@ TEST_F(TestCheckStringMsg, SuccessOnMatchWithMixedLetters)
 
 TEST_F(TestCheckStringMsg, SuccessWhenValueChanges)
 {
+  this->Initialize();
   bt_ports input = {{"topic_name", TOPIC}, {"data", "name"}};
   CreateTree(PLUGIN, input);
   auto & tree = GetTree();

--- a/husarion_ugv_manager/test/test_behavior_tree_utils.cpp
+++ b/husarion_ugv_manager/test/test_behavior_tree_utils.cpp
@@ -145,11 +145,11 @@ TEST(TestCreateRosNodeParamsFromBlackboard, NodeNullPtr)
 {
   BT::NodeConfiguration config;
   config.blackboard = BT::Blackboard::create();
-  config.blackboard->set("node", nullptr);
+  config.blackboard->set("node", rclcpp::Node::SharedPtr());
 
   EXPECT_TRUE(husarion_ugv_utils::test_utils::IsMessageThrown<BT::RuntimeError>(
     [&]() { husarion_ugv_manager::behavior_tree_utils::CreateRosNodeParamsFromBlackboard(config); },
-    "Failed to get rclcpp::Node"));
+    "rclcpp::Node is nullptr"));
 }
 
 TEST(TestCreateRosNodeParamsFromBlackboard, GoodInput)

--- a/husarion_ugv_manager/test/test_behavior_tree_utils.cpp
+++ b/husarion_ugv_manager/test/test_behavior_tree_utils.cpp
@@ -123,6 +123,51 @@ TEST_F(TestRegisterBT, RegisterBehaviorTreeROS)
   rclcpp::shutdown();
 }
 
+TEST(TestCreateRosNodeParamsFromBlackboard, EmptyBlackboard)
+{
+  BT::NodeConfiguration config;
+  EXPECT_TRUE(husarion_ugv_utils::test_utils::IsMessageThrown<std::runtime_error>(
+    [&]() { husarion_ugv_manager::behavior_tree_utils::CreateRosNodeParamsFromBlackboard(config); },
+    "Blackboard is nullptr"));
+}
+
+TEST(TestCreateRosNodeParamsFromBlackboard, MissingKeyNode)
+{
+  BT::NodeConfiguration config;
+  config.blackboard = BT::Blackboard::create();
+
+  EXPECT_TRUE(husarion_ugv_utils::test_utils::IsMessageThrown<BT::RuntimeError>(
+    [&]() { husarion_ugv_manager::behavior_tree_utils::CreateRosNodeParamsFromBlackboard(config); },
+    "Failed to get rclcpp::Node"));
+}
+
+TEST(TestCreateRosNodeParamsFromBlackboard, NodeNullPtr)
+{
+  BT::NodeConfiguration config;
+  config.blackboard = BT::Blackboard::create();
+  config.blackboard->set("node", nullptr);
+
+  EXPECT_TRUE(husarion_ugv_utils::test_utils::IsMessageThrown<BT::RuntimeError>(
+    [&]() { husarion_ugv_manager::behavior_tree_utils::CreateRosNodeParamsFromBlackboard(config); },
+    "Failed to get rclcpp::Node"));
+}
+
+TEST(TestCreateRosNodeParamsFromBlackboard, GoodInput)
+{
+  rclcpp::init(0, nullptr);
+  BT::NodeConfiguration config;
+  config.blackboard = BT::Blackboard::create();
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  config.blackboard->set("node", node);
+
+  auto params =
+    husarion_ugv_manager::behavior_tree_utils::CreateRosNodeParamsFromBlackboard(config);
+
+  EXPECT_FALSE(params.nh.expired());
+
+  rclcpp::shutdown();
+}
+
 TEST(TestConvertFromStringPoseStamped, GoodInput)
 {
   constexpr double time_threshold = 0.1;

--- a/husarion_ugv_manager/test/utils/plugin_test_utils.hpp
+++ b/husarion_ugv_manager/test/utils/plugin_test_utils.hpp
@@ -181,10 +181,11 @@ public:
   }
 
   void CreateTree(
-    const std::string & plugin_name, const std::map<std::string, std::string> & bb_ports)
+    const std::string & plugin_name, const std::map<std::string, std::string> & bb_ports,
+    BT::Blackboard::Ptr blackboard = BT::Blackboard::create())
   {
     auto xml_text = BuildBehaviorTree(plugin_name, bb_ports);
-    tree_ = factory_.createTreeFromText(xml_text);
+    tree_ = factory_.createTreeFromText(xml_text, blackboard);  
   }
 
   inline BT::Tree & GetTree() { return tree_; }

--- a/husarion_ugv_manager/test/utils/plugin_test_utils.hpp
+++ b/husarion_ugv_manager/test/utils/plugin_test_utils.hpp
@@ -185,7 +185,7 @@ public:
     BT::Blackboard::Ptr blackboard = BT::Blackboard::create())
   {
     auto xml_text = BuildBehaviorTree(plugin_name, bb_ports);
-    tree_ = factory_.createTreeFromText(xml_text, blackboard);  
+    tree_ = factory_.createTreeFromText(xml_text, blackboard);
   }
 
   inline BT::Tree & GetTree() { return tree_; }


### PR DESCRIPTION
### Description

This makes it possible to include our custom BT nodes in other packages, that does not support ROS plugin libs (e.g. nav2). It requires to pass `node` to the blackboard.

### Requirements

- [x] (Dependency PR)
- [x] Backport
- [x] Code style guidelines followed
- [x] Documentation updated
- [x] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LED animation IDs for goal-failed and flood-light scenarios.
  * Behavior tree nodes can now be loaded/registered more flexibly for use in trees.

* **Chores**
  * Exported plugin libraries as part of package exports to improve plugin availability.

* **Tests**
  * Expanded tests for plugin loading and node initialization, plus new tests for behavior-tree helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->