### PR TITLE
Fixed segfault when shuttingdown

### DIFF
--- a/husarion_ugv_gazebo/CMakeLists.txt
+++ b/husarion_ugv_gazebo/CMakeLists.txt
@@ -1,13 +1,12 @@
 cmake_minimum_required(VERSION 3.11)
 project(husarion_ugv_gazebo)
 
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wall
     -Wextra
     -Wpedantic
-    # -Werror cannot fix depricated warnings in dependencies
+    # -Werror cannot fix deprecated warnings in dependencies
     -Wsuggest-override
     -Wold-style-cast
     -Wno-array-bounds

--- a/husarion_ugv_gazebo/CMakeLists.txt
+++ b/husarion_ugv_gazebo/CMakeLists.txt
@@ -1,8 +1,20 @@
 cmake_minimum_required(VERSION 3.11)
 project(husarion_ugv_gazebo)
 
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Wshadow -Wold-style-cast)
+  add_compile_options(
+    -Wall
+    -Wextra
+    -Wpedantic
+    # -Werror cannot fix depricated warnings in dependencies
+    -Wsuggest-override
+    -Wold-style-cast
+    -Wno-array-bounds
+    -pedantic-errors
+    -Wshadow
+    -Wswitch-enum
+    -Wswitch-default)
 endif()
 
 set(PACKAGE_DEPENDENCIES

--- a/husarion_ugv_gazebo/include/husarion_ugv_gazebo/led_strip.hpp
+++ b/husarion_ugv_gazebo/include/husarion_ugv_gazebo/led_strip.hpp
@@ -18,7 +18,7 @@
 #include <chrono>
 #include <string>
 
-#include <realtime_tools/realtime_box.hpp>
+#include <realtime_tools/realtime_thread_safe_box.hpp>
 
 #include <gz/math/Color.hh>
 #include <gz/math/Pose3.hh>
@@ -137,7 +137,7 @@ private:
 
   bool new_image_available_ = false;
   gz::msgs::Light light_cmd_;
-  realtime_tools::RealtimeBox<gz::msgs::Image> last_image_;
+  realtime_tools::RealtimeThreadSafeBox<gz::msgs::Image> last_image_;
   gz::sim::Entity light_entity_{gz::sim::kNullEntity};
   gz::transport::Node node_;
   std::chrono::steady_clock::duration last_update_time_{std::chrono::seconds(

--- a/husarion_ugv_gazebo/launch/simulation.launch.py
+++ b/husarion_ugv_gazebo/launch/simulation.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
                 [FindPackageShare("husarion_gz_worlds"), "launch", "gz_sim.launch.py"]
             )
         ),
-        launch_arguments={"gz_gui": namespaced_gz_gui, "gz_log_level": "1"}.items(),
+        launch_arguments={"gz_gui": namespaced_gz_gui, "gz_log_level": "4"}.items(),
     )
 
     gz_bridge_config = PathJoinSubstitution(

--- a/husarion_ugv_gazebo/launch/simulation.launch.py
+++ b/husarion_ugv_gazebo/launch/simulation.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
                 [FindPackageShare("husarion_gz_worlds"), "launch", "gz_sim.launch.py"]
             )
         ),
-        launch_arguments={"gz_gui": namespaced_gz_gui, "gz_log_level": "4"}.items(),
+        launch_arguments={"gz_gui": namespaced_gz_gui, "gz_log_level": "1"}.items(),
     )
 
     gz_bridge_config = PathJoinSubstitution(

--- a/husarion_ugv_gazebo/src/estop_system.cpp
+++ b/husarion_ugv_gazebo/src/estop_system.cpp
@@ -22,8 +22,12 @@
 #include <vector>
 
 #include <gz/msgs/imu.pb.h>
+#include <gz/msgs/wrench.pb.h>
 #include <gz/sim/components/Imu.hh>
 #include <gz/transport/Node.hh>
+
+#define GZ_TRANSPORT_NAMESPACE gz::transport::
+#define GZ_MSGS_NAMESPACE gz::msgs::
 
 #include <hardware_interface/hardware_info.hpp>
 #include <hardware_interface/lexical_casts.hpp>
@@ -32,37 +36,92 @@
 
 struct jointData
 {
+  /// \brief Joint's names.
   std::string name;
+
+  /// \brief Joint's type.
+  sdf::JointType joint_type;
+
+  /// \brief Joint's axis.
+  sdf::JointAxis joint_axis;
+
+  /// \brief Current joint position
   double joint_position;
+
+  /// \brief Current joint velocity
   double joint_velocity;
+
+  /// \brief Current joint effort
   double joint_effort;
+
+  /// \brief Current cmd joint position
   double joint_position_cmd;
+
+  /// \brief Current cmd joint velocity
   double joint_velocity_cmd;
+
+  /// \brief Current cmd joint effort
   double joint_effort_cmd;
+
+  /// \brief flag if joint is actuated (has command interfaces) or passive
   bool is_actuated;
-  gz::sim::Entity sim_joint;
+
+  /// \brief handles to the joints from within Gazebo
+  sim::Entity sim_joint;
+
+  /// \brief Control method defined in the URDF for each joint.
   gz_ros2_control::GazeboSimSystemInterface::ControlMethod joint_control_method;
 };
 
-struct MimicJoint
+class ForceTorqueData
 {
-  std::size_t joint_index;
-  std::size_t mimicked_joint_index;
-  double multiplier = 1.0;
-  std::vector<std::string> interfaces_to_mimic;
+public:
+  /// \brief force torque sensor's name.
+  std::string name{};
+
+  /// \brief force torque sensor's topic name.
+  std::string topicName{};
+
+  /// \brief handles to the force torque from within Gazebo
+  sim::Entity sim_ft_sensors_ = sim::kNullEntity;
+
+  /// \brief An array per FT
+  std::array<double, 6> ft_sensor_data_;
+
+  /// \brief callback to get the Force Torque topic values
+  void OnForceTorque(const GZ_MSGS_NAMESPACE Wrench & _msg);
 };
+
+void ForceTorqueData::OnForceTorque(const GZ_MSGS_NAMESPACE Wrench & _msg)
+{
+  this->ft_sensor_data_[0] = _msg.force().x();
+  this->ft_sensor_data_[1] = _msg.force().y();
+  this->ft_sensor_data_[2] = _msg.force().z();
+  this->ft_sensor_data_[3] = _msg.torque().x();
+  this->ft_sensor_data_[4] = _msg.torque().y();
+  this->ft_sensor_data_[5] = _msg.torque().z();
+}
 
 class ImuData
 {
 public:
+  /// \brief imu's name.
   std::string name{};
+
+  /// \brief imu's topic name.
   std::string topicName{};
-  gz::sim::Entity sim_imu_sensors_ = gz::sim::kNullEntity;
+
+  /// \brief handles to the imu from within Gazebo
+  sim::Entity sim_imu_sensors_ = sim::kNullEntity;
+
+  /// \brief An array per IMU with 4 orientation, 3 angular velocity and 3 linear acceleration
   std::array<double, 10> imu_sensor_data_;
-  void OnIMU(const gz::msgs::IMU & _msg);
+
+  /// \brief callback to get the IMU topic values
+  void OnIMU(const GZ_MSGS_NAMESPACE IMU & _msg);
 };
 
-void ImuData::OnIMU(const gz::msgs::IMU & _msg)
+void ImuData::OnIMU(const GZ_MSGS_NAMESPACE IMU & _msg)
 {
   this->imu_sensor_data_[0] = _msg.orientation().x();
   this->imu_sensor_data_[1] = _msg.orientation().y();
@@ -80,18 +139,44 @@ class gz_ros2_control::GazeboSimSystemPrivate
 {
 public:
   GazeboSimSystemPrivate() = default;
+
   ~GazeboSimSystemPrivate() = default;
+  /// \brief Degrees od freedom.
   size_t n_dof_;
+
+  /// \brief last time the write method was called.
   rclcpp::Time last_update_sim_time_ros_;
+
+  /// \brief vector with the joint's names.
   std::vector<struct jointData> joints_;
+
+  /// \brief vector with the imus.
   std::vector<std::shared_ptr<ImuData>> imus_;
+
+  /// \brief vector with the force torque sensors.
+  std::vector<std::shared_ptr<ForceTorqueData>> ft_sensors_;
+
+  /// \brief state interfaces that will be exported to the Resource Manager
   std::vector<hardware_interface::StateInterface> state_interfaces_;
+
+  /// \brief command interfaces that will be exported to the Resource Manager
   std::vector<hardware_interface::CommandInterface> command_interfaces_;
-  gz::sim::EntityComponentManager * ecm;
-  int * update_rate;
-  gz::transport::Node node;
-  std::vector<MimicJoint> mimic_joints_;
+
+  /// \brief Entity component manager, ECM shouldn't be accessed outside those
+  /// methods, otherwise the app will crash
+  sim::EntityComponentManager * ecm;
+
+  /// \brief controller update rate
+  unsigned int update_rate;
+
+  /// \brief Gazebo communication node.
+  GZ_TRANSPORT_NAMESPACE Node node;
+
+  /// \brief Gain which converts position error to a velocity command
   double position_proportional_gain_;
+
+  // Should hold the joints if no control_mode is active
+  bool hold_joints_ = true;
 };
 
 namespace husarion_ugv_gazebo

--- a/husarion_ugv_gazebo/src/gui/EStop.qml
+++ b/husarion_ugv_gazebo/src/gui/EStop.qml
@@ -62,7 +62,6 @@ Rectangle {
     anchors.topMargin: 10
     anchors.horizontalCenter: widgetRectangle.horizontalCenter
     checkable: true
-    checked: EStop.checked
     width: 100
     height: 100
     contentItem: Rectangle {

--- a/husarion_ugv_gazebo/src/led_strip.cpp
+++ b/husarion_ugv_gazebo/src/led_strip.cpp
@@ -137,6 +137,7 @@ gz::msgs::Light LEDStrip::CreateLightMsgFromSdf(const sdf::Light & light_sdf)
     case sdf::LightType::DIRECTIONAL:
       light_cmd.set_type(gz::msgs::Light::DIRECTIONAL);
       break;
+    case sdf::LightType::INVALID:
     default:
       light_cmd.set_type(gz::msgs::Light::POINT);
       break;


### PR DESCRIPTION
### Description
- removed unused qml variable ` checked: EStop.checked`,
<img width="970" height="28" alt="Screenshot from 2025-11-21 14-58-57" src="https://github.com/user-attachments/assets/6e06f77b-d00f-421f-83a9-b78d011c0729" />

- added compilation flags to `husarion_ugv_gazebo`,
- changed depricated `RealtimeBox` to `RealtimeThreadSafeBox`
- added ` case sdf::LightType::INVALID:` to ledstrip switch case,
- updated `estop_system.cpp` external structs and classes to https://github.com/ros-controls/gz_ros2_control/blob/jazzy/gz_ros2_control/src/gz_system.cpp ,
- the last change fixed the seq fault after shuttingdown the simulation.

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [ ] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated force-torque and IMU sensor support for enhanced environmental sensing

* **Bug Fixes**
  * Improved thread safety for LED strip image processing
  * Strengthened handling of invalid light types

* **UI Updates**
  * Refined emergency stop button state management

* **Chores**
  * Expanded compiler warning flags for improved code quality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->