### PR TITLE
Parametrize cpu temperature filepath with default value set to RPi path

### DIFF
--- a/husarion_ugv_diagnostics/include/husarion_ugv_diagnostics/system_monitor_node.hpp
+++ b/husarion_ugv_diagnostics/include/husarion_ugv_diagnostics/system_monitor_node.hpp
@@ -77,7 +77,6 @@ private:
   system_monitor::Params params_;
   std::shared_ptr<system_monitor::ParamListener> param_listener_;
 
-  static constexpr char kTemperatureInfoFilename[] = "/sys/class/thermal/thermal_zone0/temp";
   static constexpr char kRootDirectory[] = "/";
 };
 }  // namespace husarion_ugv_diagnostics

--- a/husarion_ugv_diagnostics/src/system_monitor_node.cpp
+++ b/husarion_ugv_diagnostics/src/system_monitor_node.cpp
@@ -111,7 +111,7 @@ float SystemMonitorNode::GetCPUTemperature() const
   float temperature = std::numeric_limits<float>::quiet_NaN();
 
   try {
-    const auto temperature_str = filesystem_->ReadFile(kTemperatureInfoFilename);
+    const auto temperature_str = filesystem_->ReadFile(params_.cpu_temp_file_path);
     temperature = husarion_ugv_utils::common_utilities::SetPrecision(
       std::stof(temperature_str) / 1000.0, 2);
   } catch (const std::exception & e) {

--- a/husarion_ugv_diagnostics/src/system_monitor_parameters.yaml
+++ b/husarion_ugv_diagnostics/src/system_monitor_parameters.yaml
@@ -24,3 +24,7 @@ system_monitor:
     default_value: 5.0
     description: System status publishing frequency [Hz].
     validation: { bounds<>: [0.1, 10.0] }
+  cpu_temp_file_path:
+    type: string
+    default_value: "/sys/class/thermal/thermal_zone0/temp"
+    description: Path to the CPU temperature info file.


### PR DESCRIPTION
### Description
The CPU temperature file path has been replaced with the `cpu_temp_file_path` parameter. This allows specifying a different temperature file location, e.g., on NUC/AMD64 systems.

https://github.com/husarion/husarion_outdoor_nav_ros/issues/257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CPU temperature monitoring is now configurable through system parameters, allowing customization for different hardware setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->