### PR TITLE
Remapped CM diagnostics to the namespace

### DIFF
--- a/husarion_ugv_description/urdf/common/gazebo.urdf.xacro
+++ b/husarion_ugv_description/urdf/common/gazebo.urdf.xacro
@@ -37,6 +37,7 @@
         <parameters>${config_file}</parameters>
         <ros>
           <namespace>${namespace}</namespace>
+          <remapping>/diagnostics:=diagnostics</remapping>
           <remapping>drive_controller/cmd_vel:=cmd_vel</remapping>
           <remapping>drive_controller/odom:=odometry/wheels</remapping>
           <remapping>drive_controller/transition_event:=drive_controller/_transition_event</remapping>


### PR DESCRIPTION
### Description

- CM publishes the diagnostics to the `/diagnostics` by default, remapped to be published to `diagnostics` with a namespace.

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [ ] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ROS diagnostics topic remapping in Gazebo simulation for proper diagnostics message routing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->