### PR TITLE
Add parameter to disable orientation

### DIFF
--- a/husarion_ugv_controller/config/WH01_controller.yaml
+++ b/husarion_ugv_controller/config/WH01_controller.yaml
@@ -18,7 +18,7 @@
       sensor_name: <namespace>/imu
       frame_id: <namespace>/imu_link
       # orientation_stddev: 4.3e-2 rad determined experimentally
-      static_covariance_orientation: [1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
+      static_covariance_orientation: <static_covariance_orientation>
       # angular_velocity_stdev: 0.59 deg/s (0.01 rad/s) gyroscope white noise sigma, according to the manual
       static_covariance_angular_velocity: [1.0e-4, 0.0, 0.0, 0.0, 1.0e-4, 0.0, 0.0, 0.0, 1.0e-4]
       # linear_acceleration_stdev: 2.8 mg (0.0275 m/s^2) accelerometer white noise sigma, according to the manual

--- a/husarion_ugv_controller/config/WH02_controller.yaml
+++ b/husarion_ugv_controller/config/WH02_controller.yaml
@@ -18,7 +18,7 @@
       sensor_name: <namespace>/imu
       frame_id: <namespace>/imu_link
       # orientation_stddev: 4.3e-2 rad determined experimentally
-      static_covariance_orientation: [1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
+      static_covariance_orientation: <static_covariance_orientation>
       # angular_velocity_stdev: 0.59 deg/s (0.01 rad/s) gyroscope white noise sigma, according to the manual
       static_covariance_angular_velocity: [1.0e-4, 0.0, 0.0, 0.0, 1.0e-4, 0.0, 0.0, 0.0, 1.0e-4]
       # linear_acceleration_stdev: 2.8 mg (0.0275 m/s^2) accelerometer white noise sigma, according to the manual

--- a/husarion_ugv_controller/config/WH04_controller.yaml
+++ b/husarion_ugv_controller/config/WH04_controller.yaml
@@ -18,7 +18,7 @@
       sensor_name: <namespace>/imu
       frame_id: <namespace>/imu_link
       # orientation_stddev: 4.3e-2 rad determined experimentally
-      static_covariance_orientation: [1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
+      static_covariance_orientation: <static_covariance_orientation>
       # angular_velocity_stdev: 0.59 deg/s (0.01 rad/s) gyroscope white noise sigma, according to the manual
       static_covariance_angular_velocity: [1.0e-4, 0.0, 0.0, 0.0, 1.0e-4, 0.0, 0.0, 0.0, 1.0e-4]
       # linear_acceleration_stdev: 2.8 mg (0.0275 m/s^2) accelerometer white noise sigma, according to the manual

--- a/husarion_ugv_controller/config/WH05_controller.yaml
+++ b/husarion_ugv_controller/config/WH05_controller.yaml
@@ -18,7 +18,7 @@
       sensor_name: <namespace>/imu
       frame_id: <namespace>/imu_link
       # orientation_stddev: 4.3e-2 rad determined experimentally
-      static_covariance_orientation: [1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
+      static_covariance_orientation: [-10, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
       # angular_velocity_stdev: 0.59 deg/s (0.01 rad/s) gyroscope white noise sigma, according to the manual
       static_covariance_angular_velocity: [1.0e-4, 0.0, 0.0, 0.0, 1.0e-4, 0.0, 0.0, 0.0, 1.0e-4]
       # linear_acceleration_stdev: 2.8 mg (0.0275 m/s^2) accelerometer white noise sigma, according to the manual

--- a/husarion_ugv_controller/config/WH05_controller.yaml
+++ b/husarion_ugv_controller/config/WH05_controller.yaml
@@ -18,7 +18,7 @@
       sensor_name: <namespace>/imu
       frame_id: <namespace>/imu_link
       # orientation_stddev: 4.3e-2 rad determined experimentally
-      static_covariance_orientation: [-10, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
+      static_covariance_orientation: [1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
       # angular_velocity_stdev: 0.59 deg/s (0.01 rad/s) gyroscope white noise sigma, according to the manual
       static_covariance_angular_velocity: [1.0e-4, 0.0, 0.0, 0.0, 1.0e-4, 0.0, 0.0, 0.0, 1.0e-4]
       # linear_acceleration_stdev: 2.8 mg (0.0275 m/s^2) accelerometer white noise sigma, according to the manual

--- a/husarion_ugv_controller/config/WH05_controller.yaml
+++ b/husarion_ugv_controller/config/WH05_controller.yaml
@@ -18,7 +18,7 @@
       sensor_name: <namespace>/imu
       frame_id: <namespace>/imu_link
       # orientation_stddev: 4.3e-2 rad determined experimentally
-      static_covariance_orientation: [1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
+      static_covariance_orientation: <static_covariance_orientation>
       # angular_velocity_stdev: 0.59 deg/s (0.01 rad/s) gyroscope white noise sigma, according to the manual
       static_covariance_angular_velocity: [1.0e-4, 0.0, 0.0, 0.0, 1.0e-4, 0.0, 0.0, 0.0, 1.0e-4]
       # linear_acceleration_stdev: 2.8 mg (0.0275 m/s^2) accelerometer white noise sigma, according to the manual

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -129,6 +129,7 @@ def generate_launch_description():
             "namespace": namespace,
             "robot_model": robot_model,
             "log_level": log_level,
+            "publish_orientation": publish_orientation,
         }.items(),
     )
 

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -58,9 +58,9 @@ def generate_launch_description():
         choices=["lynx", "panther"],
     )
 
-    publish_orientation = LaunchConfiguration("publish_orientation")
-    declare_publish_orientation_arg = DeclareLaunchArgument(
-        "publish_orientation",
+    use_madgwick_filter = LaunchConfiguration("use_madgwick_filter")
+    declare_use_madgwick_filter_arg = DeclareLaunchArgument(
+        "use_madgwick_filter",
         default_value="False",
         description="Determine orientation from IMU",
         choices=["True", "true", "False", "false"],
@@ -129,7 +129,7 @@ def generate_launch_description():
             "namespace": namespace,
             "robot_model": robot_model,
             "log_level": log_level,
-            "publish_orientation": publish_orientation,
+            "use_madgwick_filter": use_madgwick_filter,
         }.items(),
     )
 
@@ -157,9 +157,9 @@ def generate_launch_description():
     orientation_covariance = PythonExpression(
         [
             "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
-            publish_orientation,
+            use_madgwick_filter,
             "' in ['True', 'true'] else ",
-            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
+            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",  # the first element of the orientation covariance is set to -1 according to the documentation: https://docs.ros.org/en/jazzy/p/sensor_msgs/msg/Imu.html
         ]
     )
 
@@ -238,7 +238,7 @@ def generate_launch_description():
     actions = [
         declare_common_dir_path_arg,
         declare_robot_model_arg,  # robot_model is used by wheel_type
-        declare_publish_orientation_arg,
+        declare_use_madgwick_filter_arg,
         declare_wheel_type_arg,  # wheel_type is used by controller_config_path
         declare_controller_config_path_arg,
         declare_namespace_arg,

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -162,15 +162,6 @@ def generate_launch_description():
         ]
     )
 
-    # orientation_covariance = PythonExpression(
-    #     [
-    #         "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
-    #         publish_orientation,
-    #         "\" in ['True', 'true'] else ",
-    #         "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
-    #     ]
-    # )
-
     ns_controller_config_path = ReplaceString(
         controller_config_path,
         {

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -58,6 +58,14 @@ def generate_launch_description():
         choices=["lynx", "panther"],
     )
 
+    publish_orientation = LaunchConfiguration("publish_orientation")
+    declare_publish_orientation_arg = DeclareLaunchArgument(
+        "publish_orientation",
+        default_value="False",
+        description="Determine orientation from IMU",
+        choices=["True", "true", "False", "false"],
+    )
+
     wheel_type = LaunchConfiguration("wheel_type")
     controller_config_path = LaunchConfiguration("controller_config_path")
     declare_controller_config_path_arg = DeclareLaunchArgument(
@@ -146,10 +154,35 @@ def generate_launch_description():
         ]
     )
 
+    orientation_covariance = PythonExpression(
+        [
+            "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
+            publish_orientation,
+            "' in ['True', 'true'] else ",
+            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
+        ]
+    )
+
+    # orientation_covariance = PythonExpression([
+    #     "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
+    #     publish_orientation,
+    #     "\" in ['True', 'true'] else ",
+    #     "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
+    # ])
+
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[ns_controller_config_path],
+        parameters=[
+            ns_controller_config_path,
+            {
+                "imu_broadcaster": {
+                    "ros__parameters": {
+                        "static_covariance_orientation": orientation_covariance,
+                    }
+                }
+            },
+        ],
         namespace=namespace,
         remappings=[
             ("/diagnostics", "diagnostics"),
@@ -213,6 +246,7 @@ def generate_launch_description():
     actions = [
         declare_common_dir_path_arg,
         declare_robot_model_arg,  # robot_model is used by wheel_type
+        declare_publish_orientation_arg,
         declare_wheel_type_arg,  # wheel_type is used by controller_config_path
         declare_controller_config_path_arg,
         declare_namespace_arg,

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -163,27 +163,23 @@ def generate_launch_description():
     #     ]
     # )
 
-    orientation_covariance = PythonExpression(
-        [
-            "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
-            publish_orientation,
-            "\" in ['True', 'true'] else ",
-            "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
-        ]
-    )
+    # orientation_covariance = PythonExpression(
+    #     [
+    #         "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
+    #         publish_orientation,
+    #         "\" in ['True', 'true'] else ",
+    #         "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
+    #     ]
+    # )
+
+    orientation_covariance = [-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
 
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[
             ns_controller_config_path,
-            {
-                "imu_broadcaster": {
-                    "ros__parameters": {
-                        "static_covariance_orientation": orientation_covariance,
-                    }
-                }
-            },
+            {"imu_broadcaster.static_covariance_orientation": orientation_covariance},
         ],
         namespace=namespace,
         remappings=[

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -154,21 +154,23 @@ def generate_launch_description():
         ]
     )
 
+    # orientation_covariance = PythonExpression(
+    #     [
+    #         "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
+    #         publish_orientation,
+    #         "' in ['True', 'true'] else ",
+    #         "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
+    #     ]
+    # )
+
     orientation_covariance = PythonExpression(
         [
-            "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
+            "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
             publish_orientation,
-            "' in ['True', 'true'] else ",
-            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
+            "\" in ['True', 'true'] else ",
+            "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
         ]
     )
-
-    # orientation_covariance = PythonExpression([
-    #     "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
-    #     publish_orientation,
-    #     "\" in ['True', 'true'] else ",
-    #     "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
-    # ])
 
     control_node = Node(
         package="controller_manager",

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -133,7 +133,6 @@ def generate_launch_description():
     )
 
     ns = PythonExpression(["'", namespace, "' + '/' if '", namespace, "' else ''"])
-    ns_controller_config_path = ReplaceString(controller_config_path, {"<namespace>/": ns})
 
     joint_state_broadcaster_log_unit = PythonExpression(
         [
@@ -154,33 +153,36 @@ def generate_launch_description():
         ]
     )
 
-    # orientation_covariance = PythonExpression(
-    #     [
-    #         "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
-    #         publish_orientation,
-    #         "' in ['True', 'true'] else ",
-    #         "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
-    #     ]
-    # )
+    orientation_covariance = PythonExpression(
+        [
+            "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
+            publish_orientation,
+            "' in ['True', 'true'] else ",
+            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
+        ]
+    )
 
     # orientation_covariance = PythonExpression(
     #     [
-    #         "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
+    #         "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
     #         publish_orientation,
     #         "\" in ['True', 'true'] else ",
     #         "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
     #     ]
     # )
 
-    orientation_covariance = [-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]
+    ns_controller_config_path = ReplaceString(
+        controller_config_path,
+        {
+            "<namespace>/": ns,
+            "<static_covariance_orientation>": orientation_covariance,
+        },
+    )
 
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[
-            ns_controller_config_path,
-            {"imu_broadcaster.static_covariance_orientation": orientation_covariance},
-        ],
+        parameters=[ns_controller_config_path],
         namespace=namespace,
         remappings=[
             ("/diagnostics", "diagnostics"),

--- a/husarion_ugv_description/launch/load_urdf.launch.py
+++ b/husarion_ugv_description/launch/load_urdf.launch.py
@@ -163,15 +163,6 @@ def generate_launch_description():
         ]
     )
 
-    # orientation_covariance = PythonExpression(
-    #     [
-    #         "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
-    #         publish_orientation,
-    #         "\" in ['True', 'true'] else ",
-    #         "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
-    #     ]
-    # )
-
     ns_controller_config_path = ReplaceString(
         controller_config_path,
         {

--- a/husarion_ugv_description/launch/load_urdf.launch.py
+++ b/husarion_ugv_description/launch/load_urdf.launch.py
@@ -74,6 +74,14 @@ def generate_launch_description():
         ),
     )
 
+    publish_orientation = LaunchConfiguration("publish_orientation")
+    declare_publish_orientation_arg = DeclareLaunchArgument(
+        "publish_orientation",
+        default_value="False",
+        description="Determine orientation from IMU",
+        choices=["True", "true", "False", "false"],
+    )
+
     wheel_type = LaunchConfiguration("wheel_type")
     controller_config_path = LaunchConfiguration("controller_config_path")
     declare_controller_config_path_arg = DeclareLaunchArgument(
@@ -145,7 +153,32 @@ def generate_launch_description():
     )
 
     ns = PythonExpression(["'", namespace, "' + '/' if '", namespace, "' else ''"])
-    ns_controller_config_path = ReplaceString(controller_config_path, {"<namespace>/": ns})
+
+    orientation_covariance = PythonExpression(
+        [
+            "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
+            publish_orientation,
+            "' in ['True', 'true'] else ",
+            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
+        ]
+    )
+
+    # orientation_covariance = PythonExpression(
+    #     [
+    #         "'[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]' if \"",
+    #         publish_orientation,
+    #         "\" in ['True', 'true'] else ",
+    #         "'[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]'",
+    #     ]
+    # )
+
+    ns_controller_config_path = ReplaceString(
+        controller_config_path,
+        {
+            "<namespace>/": ns,
+            "<static_covariance_orientation>": orientation_covariance,
+        },
+    )
 
     # Get URDF via xacro
     imu_pos_x = os.environ.get("ROBOT_IMU_LOCALIZATION_X", "0.168")
@@ -198,6 +231,7 @@ def generate_launch_description():
         declare_battery_config_path_arg,
         declare_components_config_path_arg,
         declare_robot_model_arg,  # robot_model is used by wheel_type
+        declare_publish_orientation_arg,
         declare_wheel_type_arg,  # wheel_type is used by controller_config_path
         declare_controller_config_path_arg,
         declare_namespace_arg,

--- a/husarion_ugv_description/launch/load_urdf.launch.py
+++ b/husarion_ugv_description/launch/load_urdf.launch.py
@@ -202,6 +202,8 @@ def generate_launch_description():
             namespace,
             " components_config_path:=",
             components_config_path,
+            " publish_orientation:=",
+            publish_orientation,
         ]
     )
 

--- a/husarion_ugv_description/launch/load_urdf.launch.py
+++ b/husarion_ugv_description/launch/load_urdf.launch.py
@@ -74,9 +74,9 @@ def generate_launch_description():
         ),
     )
 
-    publish_orientation = LaunchConfiguration("publish_orientation")
-    declare_publish_orientation_arg = DeclareLaunchArgument(
-        "publish_orientation",
+    use_madgwick_filter = LaunchConfiguration("use_madgwick_filter")
+    declare_use_madgwick_filter_arg = DeclareLaunchArgument(
+        "use_madgwick_filter",
         default_value="False",
         description="Determine orientation from IMU",
         choices=["True", "true", "False", "false"],
@@ -157,9 +157,9 @@ def generate_launch_description():
     orientation_covariance = PythonExpression(
         [
             "[1.8e-3, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3] if '",
-            publish_orientation,
+            use_madgwick_filter,
             "' in ['True', 'true'] else ",
-            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",
+            "[-1.0, 0.0, 0.0, 0.0, 1.8e-3, 0.0, 0.0, 0.0, 1.8e-3]",  # the first element of the orientation covariance is set to -1 according to the documentation: https://docs.ros.org/en/jazzy/p/sensor_msgs/msg/Imu.html
         ]
     )
 
@@ -202,8 +202,8 @@ def generate_launch_description():
             namespace,
             " components_config_path:=",
             components_config_path,
-            " publish_orientation:=",
-            publish_orientation,
+            " use_madgwick_filter:=",
+            use_madgwick_filter,
         ]
     )
 
@@ -224,7 +224,7 @@ def generate_launch_description():
         declare_battery_config_path_arg,
         declare_components_config_path_arg,
         declare_robot_model_arg,  # robot_model is used by wheel_type
-        declare_publish_orientation_arg,
+        declare_use_madgwick_filter_arg,
         declare_wheel_type_arg,  # wheel_type is used by controller_config_path
         declare_controller_config_path_arg,
         declare_namespace_arg,

--- a/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
@@ -10,7 +10,7 @@
             imu_xyz:='0.052 0.073 -0.006'
             imu_rpy:='0.0 0.0 -1.57'
             namespace:=''
-            publish_orientation:=false">
+            use_madgwick_filter:=false">
 
     <xacro:if value="${use_sim}">
       <xacro:property name="imu_xyz" value="0.052 0.073 -0.006" />
@@ -153,7 +153,7 @@
           <param name="hub_port">0</param>
           <param name="data_interval_ms">8</param>
           <param name="callback_delta_epsilon_ms">1</param>
-          <param name="publish_orientation">${publish_orientation}</param>
+          <param name="use_madgwick_filter">${use_madgwick_filter}</param>
 
           <!-- Madgwick Filter Params -->
           <param name="gain">0.00304</param>

--- a/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
@@ -153,6 +153,7 @@
           <param name="hub_port">0</param>
           <param name="data_interval_ms">8</param>
           <param name="callback_delta_epsilon_ms">1</param>
+          <param name="publish_orientation">${publish_orientation}</param>
 
           <!-- Madgwick Filter Params -->
           <param name="gain">0.00304</param>
@@ -164,7 +165,6 @@
           <param name="stateless">false</param>
           <param name="remove_gravity_vector">false</param>
           <param name="world_frame">enu</param>
-          <param name="publish_orientation">${publish_orientation}</param>
         </hardware>
 
         <sensor name="${ns}imu">

--- a/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
@@ -163,7 +163,7 @@
           <param name="mag_bias_z">0.0</param>
           <param name="use_mag">true</param>
           <param name="stateless">false</param>
-          <param name="remove_gravity_vector">true</param>
+          <param name="remove_gravity_vector">false</param>
           <param name="world_frame">enu</param>
         </hardware>
 

--- a/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
@@ -163,7 +163,7 @@
           <param name="mag_bias_z">0.0</param>
           <param name="use_mag">true</param>
           <param name="stateless">false</param>
-          <param name="remove_gravity_vector">false</param>
+          <param name="remove_gravity_vector">true</param>
           <param name="world_frame">enu</param>
         </hardware>
 

--- a/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/lynx/lynx_macro.urdf.xacro
@@ -9,7 +9,8 @@
             use_sim:=false
             imu_xyz:='0.052 0.073 -0.006'
             imu_rpy:='0.0 0.0 -1.57'
-            namespace:=''">
+            namespace:=''
+            publish_orientation:=false">
 
     <xacro:if value="${use_sim}">
       <xacro:property name="imu_xyz" value="0.052 0.073 -0.006" />
@@ -163,6 +164,7 @@
           <param name="stateless">false</param>
           <param name="remove_gravity_vector">false</param>
           <param name="world_frame">enu</param>
+          <param name="publish_orientation">${publish_orientation}</param>
         </hardware>
 
         <sensor name="${ns}imu">

--- a/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
@@ -164,7 +164,7 @@
           <param name="mag_bias_z">0.0</param>
           <param name="use_mag">true</param>
           <param name="stateless">false</param>
-          <param name="remove_gravity_vector">false</param>
+          <param name="remove_gravity_vector">true</param>
           <param name="world_frame">enu</param>
         </hardware>
 

--- a/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
@@ -9,7 +9,8 @@
             use_sim:=false
             imu_xyz:='0.169 0.025 0.092'
             imu_rpy:='0.0 0.0 -1.57'
-            namespace:=''">
+            namespace:=''
+            publish_orientation:=false">
 
     <xacro:if value="${use_sim}">
       <xacro:property name="imu_xyz" value="-0.195 0.010 0.085" />
@@ -164,6 +165,7 @@
           <param name="stateless">false</param>
           <param name="remove_gravity_vector">false</param>
           <param name="world_frame">enu</param>
+          <param name="publish_orientation">${publish_orientation}</param>
         </hardware>
 
         <sensor name="${ns}imu">

--- a/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
@@ -164,7 +164,7 @@
           <param name="mag_bias_z">0.0</param>
           <param name="use_mag">true</param>
           <param name="stateless">false</param>
-          <param name="remove_gravity_vector">true</param>
+          <param name="remove_gravity_vector">false</param>
           <param name="world_frame">enu</param>
         </hardware>
 

--- a/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
@@ -10,7 +10,7 @@
             imu_xyz:='0.169 0.025 0.092'
             imu_rpy:='0.0 0.0 -1.57'
             namespace:=''
-            publish_orientation:=false">
+            use_madgwick_filter:=false">
 
     <xacro:if value="${use_sim}">
       <xacro:property name="imu_xyz" value="-0.195 0.010 0.085" />
@@ -154,7 +154,7 @@
           <param name="hub_port">0</param>
           <param name="data_interval_ms">8</param>
           <param name="callback_delta_epsilon_ms">1</param>
-          <param name="publish_orientation">${publish_orientation}</param>
+          <param name="use_madgwick_filter">${use_madgwick_filter}</param>
 
           <!-- Madgwick Filter Params -->
           <param name="gain">0.00304</param>

--- a/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
+++ b/husarion_ugv_description/urdf/panther/panther_macro.urdf.xacro
@@ -154,6 +154,7 @@
           <param name="hub_port">0</param>
           <param name="data_interval_ms">8</param>
           <param name="callback_delta_epsilon_ms">1</param>
+          <param name="publish_orientation">${publish_orientation}</param>
 
           <!-- Madgwick Filter Params -->
           <param name="gain">0.00304</param>
@@ -165,7 +166,6 @@
           <param name="stateless">false</param>
           <param name="remove_gravity_vector">false</param>
           <param name="world_frame">enu</param>
-          <param name="publish_orientation">${publish_orientation}</param>
         </hardware>
 
         <sensor name="${ns}imu">

--- a/husarion_ugv_hardware_interfaces/README.md
+++ b/husarion_ugv_hardware_interfaces/README.md
@@ -98,7 +98,7 @@ Physical properties
 
 Additional parameters
 
-- `use_madgwick_filter` [*bool*, default: **false**]: Disable calculating orientation using the Madgwick filter. If set to *false*, the orientation in the IMU topic will contain NaNs and the first element of the orientation covariance matrix will be set to -1, according to the [documentation](https://docs.ros.org/en/jazzy/p/sensor_msgs/msg/Imu.html).
+- `use_madgwick_filter` [*bool*, default: **false**]: Whether to calculate orientation using the Madgwick filter. When *true*, orientation is computed and published. When *false* (the default), the orientation in the IMU topic will contain NaNs and the first element of the orientation covariance matrix will be set to -1, according to the [documentation](https://docs.ros.org/en/jazzy/p/sensor_msgs/msg/Imu.html).
 
 Madgwick filter settings
 

--- a/husarion_ugv_hardware_interfaces/README.md
+++ b/husarion_ugv_hardware_interfaces/README.md
@@ -96,6 +96,10 @@ Physical properties
 - `cc_t4` [*double*, default: **0.0**]: T offset value 4; see device's user guide for information on how to calibrate.
 - `cc_t5` [*double*, default: **0.0**]: T offset value 5; see device's user guide for information on how to calibrate.
 
+Additional parameters
+
+- `use_madgwick_filter` [*bool*, default: **false**]: Disable calculating orientation using the Madgwick filter. If set to *false*, the orientation in the IMU topic will contain NaNs and the first element of the orientation covariance matrix will be set to -1, according to the [documentation](https://docs.ros.org/en/jazzy/p/sensor_msgs/msg/Imu.html).
+
 Madgwick filter settings
 
 - `use_mag` [*bool*, default: **false**]: Use magnitude to calculate orientation.

--- a/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/phidget_imu_sensor/phidget_imu_sensor.hpp
+++ b/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/phidget_imu_sensor/phidget_imu_sensor.hpp
@@ -176,8 +176,6 @@ protected:
 
   bool algorithm_initialized_ = false;
   rclcpp::Time last_spatial_data_timestamp_;
-
-  bool publish_orientation_;
 };
 
 }  // namespace husarion_ugv_hardware_interfaces

--- a/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/phidget_imu_sensor/phidget_imu_sensor.hpp
+++ b/husarion_ugv_hardware_interfaces/include/husarion_ugv_hardware_interfaces/phidget_imu_sensor/phidget_imu_sensor.hpp
@@ -176,6 +176,8 @@ protected:
 
   bool algorithm_initialized_ = false;
   rclcpp::Time last_spatial_data_timestamp_;
+
+  bool publish_orientation_;
 };
 
 }  // namespace husarion_ugv_hardware_interfaces

--- a/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
+++ b/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
@@ -102,6 +102,7 @@ CallbackReturn PhidgetImuSensor::on_configure(const rclcpp_lifecycle::State &)
   RCLCPP_DEBUG_STREAM(logger_, "\tmag_bias_z " << params_.mag_bias_z);
   RCLCPP_DEBUG_STREAM(logger_, "\tstateless " << params_.stateless);
   RCLCPP_DEBUG_STREAM(logger_, "\tremove_gravity_vector " << params_.remove_gravity_vector);
+  RCLCPP_DEBUG_STREAM(logger_, "\tpublish_orientation: " << params_.publish_orientation);
 
   return CallbackReturn::SUCCESS;
 }
@@ -258,6 +259,8 @@ void PhidgetImuSensor::ReadMadgwickFilterParams()
   params_.stateless = hardware_interface::parse_bool(info_.hardware_parameters.at("stateless"));
   params_.remove_gravity_vector =
     hardware_interface::parse_bool(info_.hardware_parameters.at("remove_gravity_vector"));
+  params_.publish_orientation =
+    hardware_interface::parse_bool(info_.hardware_parameters.at("publish_orientation"));
 
   CheckMadgwickFilterWorldFrameParam();
 }
@@ -484,6 +487,11 @@ void PhidgetImuSensor::SpatialDataCallback(
       UpdateMadgwickAlgorithm(ang_vel, lin_acc, mag_compensated, dt);
     } else {
       UpdateMadgwickAlgorithmIMU(ang_vel, lin_acc, dt);
+    }
+
+    if (!params_.publish_orientation) {
+      const auto nan = std::numeric_limits<double>::quiet_NaN();
+      filter_->setOrientation(nan, nan, nan, nan);
     }
   }
 

--- a/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
+++ b/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
@@ -85,7 +85,7 @@ CallbackReturn PhidgetImuSensor::on_configure(const rclcpp_lifecycle::State &)
     logger_, "\tcallback_delta_epsilon_ms " << params_.callback_delta_epsilon_ms << "ms");
 
   RCLCPP_DEBUG_STREAM(logger_, "Additional parameters: ");
-  RCLCPP_DEBUG_STREAM(logger_, "\tpublish_orientation: " << publish_orientation_);
+  RCLCPP_DEBUG_STREAM(logger_, "\tuse_madgwick_filter: " << params_.use_madgwick_filter);
 
   try {
     ReadMadgwickFilterParams();
@@ -232,8 +232,8 @@ void PhidgetImuSensor::ReadObligatoryParams()
       "Invalid configuration: Callback epsilon is larger than the data interval.");
   }
 
-  publish_orientation_ =
-    hardware_interface::parse_bool(info_.hardware_parameters.at("publish_orientation"));
+  params_.use_madgwick_filter =
+    hardware_interface::parse_bool(info_.hardware_parameters.at("use_madgwick_filter"));
 }
 
 void PhidgetImuSensor::ReadCompassParams()
@@ -457,12 +457,23 @@ void PhidgetImuSensor::SpatialDataCallback(
     calibration_cv_.notify_one();
   }
 
+  // Skip the data callback when the Madgwick filter is not used
+  if (!params_.use_madgwick_filter) {
+    UpdateAccelerationAndGyrationStateValues(ang_vel, lin_acc);
+    const auto nan = std::numeric_limits<double>::quiet_NaN();
+    imu_sensor_state_[orientation_w] = nan;
+    imu_sensor_state_[orientation_x] = nan;
+    imu_sensor_state_[orientation_y] = nan;
+    imu_sensor_state_[orientation_z] = nan;
+    return;
+  }
+
   rclcpp::Time spatial_data_timestamp =
     rclcpp::Time(timestamp * 1e6);  // timestamp comes in milliseconds
   auto dt = (spatial_data_timestamp - last_spatial_data_timestamp_).seconds();
   last_spatial_data_timestamp_ = spatial_data_timestamp;
 
-  // Wait for the a magnitude and an acceleration to initialize the algorithm
+  // Wait for a magnitude and an acceleration to initialize the algorithm
   if (
     !algorithm_initialized_ &&
     !IsMagnitudeSynchronizedWithAccelerationAndGyration(mag_compensated)) {
@@ -491,13 +502,7 @@ void PhidgetImuSensor::SpatialDataCallback(
     } else {
       UpdateMadgwickAlgorithmIMU(ang_vel, lin_acc, dt);
     }
-
-    if (!publish_orientation_) {
-      const auto nan = std::numeric_limits<double>::quiet_NaN();
-      filter_->setOrientation(nan, nan, nan, nan);
-    }
   }
-
   UpdateAllStatesValues(ang_vel, lin_acc);
 }
 
@@ -545,12 +550,12 @@ void PhidgetImuSensor::UpdateAccelerationAndGyrationStateValues(
   imu_sensor_state_[angular_velocity_y] = ang_vel.y;
   imu_sensor_state_[angular_velocity_z] = ang_vel.z;
 
-  if (params_.remove_gravity_vector) {
+  if (params_.remove_gravity_vector) {  // cannot calculate gravity if orientation is not known: TBD
     float gx, gy, gz;
     filter_->getGravity(gx, gy, gz);
     imu_sensor_state_[linear_acceleration_x] = lin_acc.x - gx;
     imu_sensor_state_[linear_acceleration_y] = lin_acc.y - gy;
-    imu_sensor_state_[linear_acceleration_z] = lin_acc.y - gz;
+    imu_sensor_state_[linear_acceleration_z] = lin_acc.z - gz;
   } else {
     imu_sensor_state_[linear_acceleration_x] = lin_acc.x;
     imu_sensor_state_[linear_acceleration_y] = lin_acc.y;

--- a/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
+++ b/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
@@ -550,7 +550,9 @@ void PhidgetImuSensor::UpdateAccelerationAndGyrationStateValues(
   imu_sensor_state_[angular_velocity_y] = ang_vel.y;
   imu_sensor_state_[angular_velocity_z] = ang_vel.z;
 
-  if (params_.remove_gravity_vector) {  // cannot calculate gravity if orientation is not known: TBD
+  // Gravity vector is calculated based on the orientation, so gravity vector can be subtracted only
+  // if orientation is calculated and available (when parameter use_madgwick_filter is true)
+  if (params_.remove_gravity_vector && params_.use_madgwick_filter) {
     float gx, gy, gz;
     filter_->getGravity(gx, gy, gz);
     imu_sensor_state_[linear_acceleration_x] = lin_acc.x - gx;

--- a/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
+++ b/husarion_ugv_hardware_interfaces/src/phidget_imu_sensor/phidget_imu_sensor.cpp
@@ -84,6 +84,9 @@ CallbackReturn PhidgetImuSensor::on_configure(const rclcpp_lifecycle::State &)
   RCLCPP_DEBUG_STREAM(
     logger_, "\tcallback_delta_epsilon_ms " << params_.callback_delta_epsilon_ms << "ms");
 
+  RCLCPP_DEBUG_STREAM(logger_, "Additional parameters: ");
+  RCLCPP_DEBUG_STREAM(logger_, "\tpublish_orientation: " << publish_orientation_);
+
   try {
     ReadMadgwickFilterParams();
     ConfigureMadgwickFilter();
@@ -102,7 +105,6 @@ CallbackReturn PhidgetImuSensor::on_configure(const rclcpp_lifecycle::State &)
   RCLCPP_DEBUG_STREAM(logger_, "\tmag_bias_z " << params_.mag_bias_z);
   RCLCPP_DEBUG_STREAM(logger_, "\tstateless " << params_.stateless);
   RCLCPP_DEBUG_STREAM(logger_, "\tremove_gravity_vector " << params_.remove_gravity_vector);
-  RCLCPP_DEBUG_STREAM(logger_, "\tpublish_orientation: " << params_.publish_orientation);
 
   return CallbackReturn::SUCCESS;
 }
@@ -229,6 +231,9 @@ void PhidgetImuSensor::ReadObligatoryParams()
     throw std::runtime_error(
       "Invalid configuration: Callback epsilon is larger than the data interval.");
   }
+
+  publish_orientation_ =
+    hardware_interface::parse_bool(info_.hardware_parameters.at("publish_orientation"));
 }
 
 void PhidgetImuSensor::ReadCompassParams()
@@ -259,8 +264,6 @@ void PhidgetImuSensor::ReadMadgwickFilterParams()
   params_.stateless = hardware_interface::parse_bool(info_.hardware_parameters.at("stateless"));
   params_.remove_gravity_vector =
     hardware_interface::parse_bool(info_.hardware_parameters.at("remove_gravity_vector"));
-  params_.publish_orientation =
-    hardware_interface::parse_bool(info_.hardware_parameters.at("publish_orientation"));
 
   CheckMadgwickFilterWorldFrameParam();
 }
@@ -489,7 +492,7 @@ void PhidgetImuSensor::SpatialDataCallback(
       UpdateMadgwickAlgorithmIMU(ang_vel, lin_acc, dt);
     }
 
-    if (!params_.publish_orientation) {
+    if (!publish_orientation_) {
       const auto nan = std::numeric_limits<double>::quiet_NaN();
       filter_->setOrientation(nan, nan, nan, nan);
     }

--- a/husarion_ugv_hardware_interfaces/src/phidgets_spatial_parameters.yaml
+++ b/husarion_ugv_hardware_interfaces/src/phidgets_spatial_parameters.yaml
@@ -142,3 +142,8 @@ phidgets_spatial:
     default_value: false,
     description: "The gravity vector is kept in the IMU message."
   }
+  use_madgwick_filter: {
+    type: bool,
+    default_value: false,
+    description: "Whether to calculate Madgwick filter or not"
+  }

--- a/husarion_ugv_hardware_interfaces/src/phidgets_spatial_parameters.yaml
+++ b/husarion_ugv_hardware_interfaces/src/phidgets_spatial_parameters.yaml
@@ -139,7 +139,7 @@ phidgets_spatial:
   }
   remove_gravity_vector: {
     type: bool,
-    default_value: false,
+    default_value: true,
     description: "The gravity vector is kept in the IMU message."
   }
   use_madgwick_filter: {

--- a/husarion_ugv_hardware_interfaces/src/phidgets_spatial_parameters.yaml
+++ b/husarion_ugv_hardware_interfaces/src/phidgets_spatial_parameters.yaml
@@ -139,7 +139,7 @@ phidgets_spatial:
   }
   remove_gravity_vector: {
     type: bool,
-    default_value: true,
+    default_value: false,
     description: "The gravity vector is kept in the IMU message."
   }
   use_madgwick_filter: {


### PR DESCRIPTION
### Description
Add parameter to disable publishing orientation. Orientation in IMU topic contains NaNs and covariance orientation[0] is equal to -1 ([documentation](https://docs.ros2.org/foxy/api/sensor_msgs/msg/Imu.html)).

To work on the real robot, it is needed to add on the built-in computer in `/config/husarion_ugv_controller/config/WH0x_controller.yaml`  the placeholder: `static_covariance_orientation: <static_covariance_orientation>`.

### Tests 🧪

- [x] Robot
- [x] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Madgwick filter toggle for IMU processing (launch, URDF and hardware configs; default: false).
  * IMU orientation covariance made configurable instead of hardcoded.

* **Bug Fixes**
  * Fixed gravity subtraction logic in acceleration processing; updated IMU orientation behavior when filter is disabled.

* **Documentation**
  * Added docs describing the new parameter and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->