### PR TITLE
Fix duplicate `robot_state_publisher` nodes during sim

### DIFF
--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -230,6 +230,7 @@ def generate_launch_description():
         declare_wheel_type_arg,  # wheel_type is used by controller_config_path
         declare_controller_config_path_arg,
         declare_namespace_arg,
+        declare_publish_robot_state_arg,
         declare_use_sim_arg,
         declare_log_level_arg,
         SetParameter(name="use_sim_time", value=use_sim),

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -76,15 +76,18 @@ def generate_launch_description():
         ),
     )
 
-    actions = [
-        declare_common_dir_path_arg,
-        declare_robot_model_arg,  # robot_model is used by wheel_type
-        declare_wheel_type_arg,  # wheel_type is used by controller_config_path
-        declare_controller_config_path_arg,
-        declare_namespace_arg,
-        declare_publish_robot_state_arg,
-        declare_use_sim_arg,
-        declare_log_level_arg,
+    publish_robot_state = LaunchConfiguration("publish_robot_state")
+    declare_publish_robot_state_arg = DeclareLaunchArgument(
+        "publish_robot_state",
+        default_value="True",
+        description=(
+            "Whether to publish the robot state using a robot_state_publisher node."
+            " This should generally be set to 'True' when using real hardware, and"
+            " 'False' when running in simulation, since Gazebo will publish the robot"
+            " state in that case."
+        ),
+        choices=["True", "true", "False", "false"],
+    )
 
     log_level = LaunchConfiguration("log_level")
     declare_log_level_arg = DeclareLaunchArgument(

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -76,18 +76,15 @@ def generate_launch_description():
         ),
     )
 
-    publish_robot_state = LaunchConfiguration("publish_robot_state")
-    declare_publish_robot_state_arg = DeclareLaunchArgument(
-        "publish_robot_state",
-        default_value="True",
-        description=(
-            "Whether to publish the robot state using a robot_state_publisher node."
-            " This should generally be set to 'True' when using real hardware, and"
-            " 'False' when running in simulation, since Gazebo will publish the robot"
-            " state in that case."
-        ),
-        choices=["True", "true", "False", "false"],
-    )
+    actions = [
+        declare_common_dir_path_arg,
+        declare_robot_model_arg,  # robot_model is used by wheel_type
+        declare_wheel_type_arg,  # wheel_type is used by controller_config_path
+        declare_controller_config_path_arg,
+        declare_namespace_arg,
+        declare_publish_robot_state_arg,
+        declare_use_sim_arg,
+        declare_log_level_arg,
 
     log_level = LaunchConfiguration("log_level")
     declare_log_level_arg = DeclareLaunchArgument(

--- a/husarion_ugv_controller/launch/controller.launch.py
+++ b/husarion_ugv_controller/launch/controller.launch.py
@@ -18,7 +18,7 @@
 from husarion_ugv_utils.logging import limit_log_level_to_info
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, Shutdown
-from launch.conditions import UnlessCondition
+from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
     EnvironmentVariable,
@@ -76,6 +76,19 @@ def generate_launch_description():
         ),
     )
 
+    publish_robot_state = LaunchConfiguration("publish_robot_state")
+    declare_publish_robot_state_arg = DeclareLaunchArgument(
+        "publish_robot_state",
+        default_value="True",
+        description=(
+            "Whether to publish the robot state using a robot_state_publisher node."
+            " This should generally be set to 'True' when using real hardware, and"
+            " 'False' when running in simulation, since Gazebo will publish the robot"
+            " state in that case."
+        ),
+        choices=["True", "true", "False", "false"],
+    )
+
     log_level = LaunchConfiguration("log_level")
     declare_log_level_arg = DeclareLaunchArgument(
         "log_level",
@@ -122,6 +135,7 @@ def generate_launch_description():
             "robot_model": robot_model,
             "log_level": log_level,
         }.items(),
+        condition=IfCondition(publish_robot_state),
     )
 
     ns = PythonExpression(["'", namespace, "' + '/' if '", namespace, "' else ''"])


### PR DESCRIPTION
### Description

This PR ensures only one `robot_state_publisher` node runs when the simulation is started.

The controller isn't supposed to start its own state publisher by passing the following argument https://github.com/husarion/husarion_ugv_ros/blob/a260518d91a5393825dc38aa53e3c379023eefd6/husarion_ugv_gazebo/launch/simulate_robot.launch.py#L167 but that argument is never recognised. Our PR fixes that. This ensures the state publisher started by the simulation launch is the only one https://github.com/husarion/husarion_ugv_ros/blob/a260518d91a5393825dc38aa53e3c379023eefd6/husarion_ugv_gazebo/launch/spawn_robot.launch.py#L92

This helps avoid the warning shown when running `ros2 node list` and other related issues
```sh
❯ ros2 node list
WARNING: Be aware that there are nodes in the graph that share an exact name, which can have unintended side effects.
```

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [x] Code style guidelines followed
- [ ] Documentation updated
- [ ] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [ ] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a launch-time option to enable or disable robot state publishing (enabled by default).
  * URDF/model resources and related startup steps are now loaded only when robot state publishing is enabled, reducing unnecessary initialization when disabled.
  * The new option is exposed alongside existing launch settings (namespace, log level) for consistent runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->