### PR TITLE
Bump behaviortree_cpp to 4.9.0 to fix Missing parent blackboard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,8 +81,10 @@ repos:
       - id: ament_copyright
         name: ament_copyright
         description: Check if copyright notice is available in all files.
-        entry: ament_copyright
+        stages: [pre-commit]
+        entry: bash -c 'source /opt/ros/jazzy/setup.bash && ament_copyright "$@"' --
         language: system
+        exclude: ^.*\.md$
 
     # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8

--- a/husarion_ugv/hardware_deps.repos
+++ b/husarion_ugv/hardware_deps.repos
@@ -2,7 +2,7 @@ repositories:
   behaviortree_cpp:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP
-    version: 3ff6a32ba0497a08519c77a1436e3b81eff1bcd6
+    version: 4.9.0
   behaviortree_ros2:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.ROS2

--- a/husarion_ugv/hardware_deps.repos
+++ b/husarion_ugv/hardware_deps.repos
@@ -2,7 +2,7 @@ repositories:
   behaviortree_cpp:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP
-    version: 2626fc59f82e6c5580fdd1ab48ad7b0e26583c2f
+    version: 3ff6a32ba0497a08519c77a1436e3b81eff1bcd6
   behaviortree_ros2:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.ROS2

--- a/husarion_ugv/simulation_deps.repos
+++ b/husarion_ugv/simulation_deps.repos
@@ -2,7 +2,7 @@ repositories:
   behaviortree_cpp:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP
-    version: 3ff6a32ba0497a08519c77a1436e3b81eff1bcd6
+    version: 4.9.0
   behaviortree_ros2:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.ROS2

--- a/husarion_ugv/simulation_deps.repos
+++ b/husarion_ugv/simulation_deps.repos
@@ -2,7 +2,7 @@ repositories:
   behaviortree_cpp:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP
-    version: 2626fc59f82e6c5580fdd1ab48ad7b0e26583c2f
+    version: 3ff6a32ba0497a08519c77a1436e3b81eff1bcd6
   behaviortree_ros2:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.ROS2

--- a/husarion_ugv_manager/behavior_trees/lights.xml
+++ b/husarion_ugv_manager/behavior_trees/lights.xml
@@ -5,7 +5,7 @@
       <Parallel name="ChargingSequence"
                 failure_count="1"
                 success_count="-1"
-                _skipIf="battery_status != POWER_SUPPLY_STATUS_CHARGING \&#10;&amp;&amp; battery_status != POWER_SUPPLY_STATUS_FULL">
+                _skipIf="battery_status != POWER_SUPPLY_STATUS_CHARGING &#10;&amp;&amp; battery_status != POWER_SUPPLY_STATUS_FULL">
         <Delay delay_msec="300"
                _skipIf="current_battery_anim_id == CHARGING_BATTERY_ANIM_ID ||&#10;current_battery_anim_id == BATTERY_CHARGED_ANIM_ID">
           <CallSetLedAnimationService name="SetChargerInsertedAnimation"
@@ -15,29 +15,29 @@
                                       service_name="lights/set_animation"/>
         </Delay>
         <Delay delay_msec="2500"
-               _skipIf="(battery_percent_round == charging_anim_percent  \&#10;&amp;&amp; current_battery_anim_id == CHARGING_BATTERY_ANIM_ID\&#10;|| battery_percent_round == 1.0)">
+               _skipIf="(battery_percent_round == charging_anim_percent  &#10;&amp;&amp; current_battery_anim_id == CHARGING_BATTERY_ANIM_ID&#10;|| battery_percent_round == 1.0)">
           <CallSetLedAnimationService name="SetChargingAnimation"
                                       id="{CHARGING_BATTERY_ANIM_ID}"
                                       param="{battery_percent_round}"
                                       repeating="true"
                                       service_name="lights/set_animation"
-                                      _onSuccess="charging_anim_percent = battery_percent_round; \&#10;current_battery_anim_id = CHARGING_BATTERY_ANIM_ID"/>
+                                      _onSuccess="charging_anim_percent = battery_percent_round; &#10;current_battery_anim_id = CHARGING_BATTERY_ANIM_ID"/>
         </Delay>
         <Delay delay_msec="2500"
-               _skipIf="battery_percent_round != 1.0 \&#10;|| current_battery_anim_id == BATTERY_CHARGED_ANIM_ID">
+               _skipIf="battery_percent_round != 1.0 &#10;|| current_battery_anim_id == BATTERY_CHARGED_ANIM_ID">
           <CallSetLedAnimationService name="SetChargedAnimation"
                                       id="{BATTERY_CHARGED_ANIM_ID}"
                                       param="{battery_percent_round}"
                                       repeating="true"
                                       service_name="lights/set_animation"
-                                      _onSuccess="charging_anim_percent = battery_percent_round; \&#10;current_battery_anim_id = BATTERY_CHARGED_ANIM_ID"/>
+                                      _onSuccess="charging_anim_percent = battery_percent_round; &#10;current_battery_anim_id = BATTERY_CHARGED_ANIM_ID"/>
         </Delay>
       </Parallel>
       <Sequence name="DischargingSequence"
-                _skipIf="battery_status != POWER_SUPPLY_STATUS_DISCHARGING \&#10;&amp;&amp; battery_status != POWER_SUPPLY_STATUS_NOT_CHARGING">
+                _skipIf="battery_status != POWER_SUPPLY_STATUS_DISCHARGING &#10;&amp;&amp; battery_status != POWER_SUPPLY_STATUS_NOT_CHARGING">
         <Sequence name="BatteryStatusSequence">
           <TickAfterTimeout timeout="{LOW_BATTERY_ANIM_PERIOD}"
-                            _skipIf="battery_percent &lt; CRITICAL_BATTERY_THRESHOLD_PERCENT \&#10;|| battery_percent &gt;= LOW_BATTERY_THRESHOLD_PERCENT">
+                            _skipIf="battery_percent &lt; CRITICAL_BATTERY_THRESHOLD_PERCENT &#10;|| battery_percent &gt;= LOW_BATTERY_THRESHOLD_PERCENT">
             <CallSetLedAnimationService name="SetLowBatteryAnimation"
                                         id="{LOW_BATTERY_ANIM_ID}"
                                         param="{battery_percent_round}"
@@ -49,14 +49,14 @@
                                       param="{battery_percent_round}"
                                       repeating="true"
                                       service_name="lights/set_animation"
-                                      _skipIf="battery_percent &gt;= CRITICAL_BATTERY_THRESHOLD_PERCENT \&#10;|| current_battery_anim_id == CRITICAL_BATTERY_ANIM_ID"
+                                      _skipIf="battery_percent &gt;= CRITICAL_BATTERY_THRESHOLD_PERCENT &#10;|| current_battery_anim_id == CRITICAL_BATTERY_ANIM_ID"
                                       _onSuccess="current_battery_anim_id = CRITICAL_BATTERY_ANIM_ID"/>
           <CallSetLedAnimationService name="SetNominalBatteryAnimation"
                                       id="{BATTERY_NOMINAL_ANIM_ID}"
                                       param=""
                                       repeating="false"
                                       service_name="lights/set_animation"
-                                      _skipIf="battery_percent &lt; LOW_BATTERY_THRESHOLD_PERCENT  \&#10;|| current_battery_anim_id == BATTERY_NOMINAL_ANIM_ID"
+                                      _skipIf="battery_percent &lt; LOW_BATTERY_THRESHOLD_PERCENT  &#10;|| current_battery_anim_id == BATTERY_NOMINAL_ANIM_ID"
                                       _onSuccess="current_battery_anim_id = BATTERY_NOMINAL_ANIM_ID"/>
         </Sequence>
       </Sequence>
@@ -71,7 +71,7 @@
                                     param=""
                                     repeating="true"
                                     service_name="lights/set_animation"
-                                    _skipIf="battery_status != POWER_SUPPLY_STATUS_CHARGING \&#10;|| battery_health != POWER_SUPPLY_HEALTH_OVERHEAT"
+                                    _skipIf="battery_status != POWER_SUPPLY_STATUS_CHARGING &#10;|| battery_health != POWER_SUPPLY_HEALTH_OVERHEAT"
                                     _onSuccess="current_error_anim_id = ERROR_ANIM_ID"/>
         <CallSetLedAnimationService name="SetErrorAnimation"
                                     id="{ERROR_ANIM_ID}"
@@ -87,7 +87,7 @@
                                     param=""
                                     repeating="true"
                                     service_name="lights/set_animation"
-                                    _skipIf="battery_status == POWER_SUPPLY_STATUS_UNKNOWN \&#10;|| (battery_status == POWER_SUPPLY_STATUS_CHARGING \&#10;&amp;&amp; battery_health == POWER_SUPPLY_HEALTH_OVERHEAT)"
+                                    _skipIf="battery_status == POWER_SUPPLY_STATUS_UNKNOWN &#10;|| (battery_status == POWER_SUPPLY_STATUS_CHARGING &#10;&amp;&amp; battery_health == POWER_SUPPLY_HEALTH_OVERHEAT)"
                                     _onSuccess="current_error_anim_id = NO_ERROR_ANIM_ID"/>
       </Sequence>
     </Sequence>

--- a/husarion_ugv_manager/behavior_trees/safety.xml
+++ b/husarion_ugv_manager/behavior_trees/safety.xml
@@ -46,7 +46,7 @@
                         timeout="{FAN_TURN_OFF_TIMEOUT}">
         <Sequence>
           <Sequence name="HighSysTempSequence"
-                    _skipIf="cpu_temp &lt;= CPU_FAN_ON_TEMP \
+                    _skipIf="cpu_temp &lt;= CPU_FAN_ON_TEMP
 &amp;&amp; driver_temp &lt;= DRIVER_FAN_ON_TEMP">
             <CallSetBoolService name="EnableFan"
                                 data="true"
@@ -56,9 +56,9 @@
           <CallSetBoolService name="DisableFan"
                               data="false"
                               service_name="hardware/fan_enable"
-                              _skipIf="cpu_temp &gt; CPU_FAN_OFF_TEMP \
-|| driver_temp &gt; DRIVER_FAN_OFF_TEMP \
-|| battery_health == POWER_SUPPLY_HEALTH_OVERHEAT \
+                              _skipIf="cpu_temp &gt; CPU_FAN_OFF_TEMP
+|| driver_temp &gt; DRIVER_FAN_OFF_TEMP
+|| battery_health == POWER_SUPPLY_HEALTH_OVERHEAT
 || (!fan_state)"/>
         </Sequence>
       </TickAfterTimeout>

--- a/husarion_ugv_manager/test/test_behavior_tree_utils.cpp
+++ b/husarion_ugv_manager/test/test_behavior_tree_utils.cpp
@@ -220,7 +220,7 @@ TEST(TestConvertFromStringVectorOfDouble, GoodInput)
 TEST(TestConvertFromStringVectorOfFloat, WrongInput)
 {
   auto str = "1;2;3;0.1;a;0.2";
-  EXPECT_THROW(BT::convertFromString<std::vector<float>>(str), std::invalid_argument);
+  EXPECT_THROW(BT::convertFromString<std::vector<float>>(str), BT::RuntimeError);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
### Description

The previous pin (4.8.4) had a bug in Blackboard::createEntryImpl that threw "Missing parent blackboard" on set() against a freshly created root blackboard. This crashed lights_manager_node at runtime and broke the unit test TestBehaviorTreeManager.CreateBTConfig.

BT.CPP 4.9.0 fixes the root cause. Adapt to the syntactic API changes that come with it:

- BT script parser no longer accepts `\<newline>` line continuation; raw newlines act as token separators. Strip the trailing backslash from 11 scripts in lights.xml and 2 in safety.xml. Scripts remain semantically identical.
- BT::convertFromString<vector<float>> now throws BT::RuntimeError instead of std::invalid_argument on bad input; update the test expectation accordingly.

### Requirements

- [ ] (Dependency PR)
- [ ] Backport
- [x] Code style guidelines followed
- [x] Documentation updated
- [x] Other repositories updated `.repos`

### Tests 🧪

- [ ] Robot
- [ ] Container
- [x] Simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated behavior tree framework dependencies to latest version.

* **Updates**
  * Enhanced lights animation system with improved battery state detection and error handling.
  * Refined safety system logic for thermal management and charging state conditions.

* **Tests**
  * Updated test expectations for error handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->